### PR TITLE
Check for valid window before doing some actions

### DIFF
--- a/src/mwin/windefw.c
+++ b/src/mwin/windefw.c
@@ -74,6 +74,9 @@ DefWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 	CHAR		szTitle[64];
 	static POINT 	startpt;
 
+	if (!IsWindow(hwnd))
+		return FALSE;
+
 	switch(msg) {
 	case WM_NCCALCSIZE:
 		/* calculate client rect from passed window rect in rgrc[0]*/

--- a/src/mwin/wingdi.c
+++ b/src/mwin/wingdi.c
@@ -53,6 +53,9 @@ GetDCEx(HWND hwnd,HRGN hrgnClip,DWORD flags)
 {
 	HDC	hdc;
 
+	if (!IsWindow(hwnd) && (hwnd))
+		return NULL;
+
 	if(!hwnd)		/* handle NULL hwnd => desktop*/
 		hwnd = rootwp;
 

--- a/src/mwin/winuser.c
+++ b/src/mwin/winuser.c
@@ -885,6 +885,9 @@ SetFocus(HWND hwnd)
 	if(!hwnd || hwnd->unmapcount)
 		hwnd = rootwp;
 
+	if (!IsWindow(hwnd))
+		return FALSE;
+
 	if(hwnd == focuswp)
 		return focuswp;
 
@@ -1444,6 +1447,9 @@ SetWindowPos(HWND hwnd, HWND hwndInsertAfter, int x, int y, int cx, int cy,
 	WINDOWPOS	winpos;
 
 	if(!hwnd || hwnd == rootwp || cx < 0 || cy < 0)
+		return FALSE;
+
+	if (!IsWindow(hwnd))
 		return FALSE;
 
 	/* FIXME SWP_NOACTIVATE*/


### PR DESCRIPTION
These set of checks for valid window was required during showing of pop ups in Webassembly.
When popup window get destroyed, something would still try to send msg to them -which could be fault of my C# code- and will cause a crash!