### PR TITLE
SetLayeredWindowAttributes and GetLayeredWindowAttributes

### DIFF
--- a/src/include/windows.h
+++ b/src/include/windows.h
@@ -141,6 +141,9 @@ struct hwnd {
 	int		paintSerial;	/* experimental serial # for alphblend*/
 	int		paintNC;	/* experimental NC paint handling*/
 	int		nEraseBkGnd;	/* for InvalidateXX erase bkgnd flag */
+	unsigned int     color_key;       /* color key for a layered window */
+	unsigned int     alpha;           /* alpha value for a layered window */
+	unsigned int     layered_flags;   /* flags for a layered window */
 	HBRUSH		paintBrush;	/* brush created to paint some controls */
 	HPEN		paintPen;	/* pen created to paint some controls */
 	MWCLIPREGION *	update;		/* update region in screen coords*/

--- a/src/mwin/winuser.c
+++ b/src/mwin/winuser.c
@@ -869,6 +869,26 @@ UpdateWindow(HWND hwnd)
 #endif
 }
 
+BOOL WINAPI	SetLayeredWindowAttributes(HWND hwnd, COLORREF crKey, BYTE bAlpha, DWORD dwFlags)
+{
+	if (!hwnd || hwnd->unmapcount)
+		hwnd = rootwp;
+	hwnd->color_key = crKey;
+	hwnd->alpha = bAlpha;
+	hwnd->layered_flags = dwFlags;
+	return TRUE;
+}
+
+BOOL WINAPI GetLayeredWindowAttributes(HWND     hwnd, COLORREF *pcrKey, BYTE     *pbAlpha, DWORD    *pdwFlags)
+{
+	if (!hwnd || hwnd->unmapcount)
+		hwnd = rootwp;
+	*pcrKey = hwnd->color_key;
+	*pbAlpha = hwnd->alpha;
+	*pdwFlags = hwnd->layered_flags;
+	return TRUE;
+}
+
 HWND WINAPI
 GetFocus(VOID)
 {


### PR DESCRIPTION
They are stub functions that just store values. But makes my framework work.