### PR TITLE
Make MWBUTTON defines compatible with windows

### DIFF
--- a/src/include/mwtypes.h
+++ b/src/include/mwtypes.h
@@ -1434,12 +1434,13 @@ typedef struct {
 #endif /* MWINCLUDECOLORS*/
 
 /* Mouse button bits*/
-#define MWBUTTON_L	04
-#define MWBUTTON_M	02
-#define MWBUTTON_R	01
+#define MWBUTTON_L	01
+#define MWBUTTON_R	02
+#define MWBUTTON_F	08
+#define MWBUTTON_M	10
 #define MWBUTTON_U	16
 #define MWBUTTON_D	32
-#define MWBUTTON_F	08
+
 
 /* Keyboard values*/
 typedef unsigned short	MWKEY;


### PR DESCRIPTION
These definitions were not compatible with what was used in Windows as they were passed back to my system they would cause different really hard to pin problems!