### PR TITLE
Mouse driver (Raspberry Pi)

### DIFF
--- a/src/drivers/mou_devmice.c
+++ b/src/drivers/mou_devmice.c
@@ -153,10 +153,10 @@ Mice_Read(MWCOORD *dx, MWCOORD *dy, MWCOORD *dz, int *bp)
 // remap these bits to Nano-X expected format
 
 	if (left)	button |= MWBUTTON_L;
-	if (middle)	button |= MW_BUTTON_M;
-	if (right)	button |= MW_button_R;
+	if (middle)	button |= MWBUTTON_M;
+	if (right)	button |= MWBUTTON_R;
 
-	*bp = buttons;
+	*bp = button;
 
 // mwtypes.h:268:typedef int    MWCOORD;        // device coordinates
 


### PR DESCRIPTION
Hello.
My env - Raspbian GNU/Linux 8 (jessie)
Microwindows config - config.linux-fb
Here is make output
`
Compiling drivers/mou_devmice.c ...
/var/tmp/gh/microwindows/src/drivers/mou_devmice.c: In function ‘Mice_Read’:
/var/tmp/gh/microwindows/src/drivers/mou_devmice.c:156:24: error: ‘MW_BUTTON_M’ undeclared (first use in this function)
  if (middle) button |= MW_BUTTON_M;
                        ^
/var/tmp/gh/microwindows/src/drivers/mou_devmice.c:156:24: note: each undeclared identifier is reported only once for each function it appears in
/var/tmp/gh/microwindows/src/drivers/mou_devmice.c:157:23: error: ‘MW_button_R’ undeclared (first use in this function)
  if (right) button |= MW_button_R;
                       ^
/var/tmp/gh/microwindows/src/drivers/mou_devmice.c:159:8: error: ‘buttons’ undeclared (first use in this function)
  *bp = buttons;
        ^
/var/tmp/gh/microwindows/src/Makefile.rules:538: recipe for target '/var/tmp/gh/microwindows/src/obj/drivers/mou_devmice.o' failed
make[1]: *** [/var/tmp/gh/microwindows/src/obj/drivers/mou_devmice.o] Error 1
/var/tmp/gh/microwindows/src/Makefile.rules:466: recipe for target 'subdir-/var/tmp/gh/microwindows/src/engine' failed
make: *** [subdir-/var/tmp/gh/microwindows/src/engine] Error 2
`