### PR TITLE
Support & fix (re-upload of #44)

### DIFF
--- a/src/drivers/fb.c
+++ b/src/drivers/fb.c
@@ -239,6 +239,7 @@ gen_getscreeninfo(PSD psd, PMWSCREENINFO psi)
 		psi->gmask = GMASKRGBA;
 		psi->bmask = BMASKRGBA;
 		psi->amask = AMASKRGBA;
+		break;
 	case MWIF_BGR888:
 		psi->rmask = RMASKBGR;
 		psi->gmask = GMASKBGR;

--- a/src/images/tools/makebmp.c
+++ b/src/images/tools/makebmp.c
@@ -8,7 +8,11 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
+#ifndef _WIN32
 #include <unistd.h>
+#else
+#define unlink _unlink
+#endif
 #include <string.h>
 
 #define BI_RGB		0L

--- a/src/mwin/winfont.c
+++ b/src/mwin/winfont.c
@@ -33,7 +33,7 @@ CreateFont(int nHeight, int nWidth, int nEscapement, int nOrientation,
 	lf.lfClipPrecision = fdwClipPrecision;
 	lf.lfQuality = fdwQuality;
 	lf.lfPitchAndFamily = fdwPitchAndFamily;
-	strncpy(lf.lfFaceName, lpszFace, sizeof(lf.lfFaceName));
+	strncpy(lf.lfFaceName, lpszFace, sizeof(lf.lfFaceName) - 1);
 
 	return CreateFontIndirect(&lf);
 }
@@ -300,7 +300,7 @@ EnumFonts(
 		GdGetFontInfo((PMWFONT) pf, &fi);
 		set_text_metrics(hdc, lptm, &fi);
 
-		strncpy(lf.lfFaceName, pf->name, sizeof(lf.lfFaceName));
+		strncpy(lf.lfFaceName, pf->name, sizeof(lf.lfFaceName) - 1);
 		lf.lfHeight = fi.height;
 		lf.lfWidth = fi.widths['x'];
 		lf.lfWeight = FW_NORMAL;

--- a/src/mwin/winres.c
+++ b/src/mwin/winres.c
@@ -753,6 +753,7 @@ resLoadBitmap(HINSTANCE hInst, LPCTSTR resName)
 static PMWIMAGEHDR
 resDecodeBitmap(unsigned char *buffer, int size)
 {
+#if HAVE_BMP_SUPPORT
 	PSD			pmd;
 	buffer_t stream;
 
@@ -760,6 +761,9 @@ resDecodeBitmap(unsigned char *buffer, int size)
 	pmd = GdDecodeBMP(&stream, FALSE);	/* don't read file hdr*/
 
 	return (PMWIMAGEHDR)pmd;		//FIXME uses shared header for now
+#else
+	return NULL;
+#endif
 }
 
 /*


### PR DESCRIPTION
1) Add BMP format compilation in case of HAVE_BMP_SUPPORT is set to N.
2) Add Visual Studio / Win32 support in the BMP file converter souce.
3) Fix in gen_getscreeninfo() to add a break within 'case MWIF_RGBA8888'.
4) Potential fix for a string manipulation in the fonts.