### PR TITLE
Fix win32 api fontname string copies and compiler warnings

### DIFF
--- a/src/include/wingdi.h
+++ b/src/include/wingdi.h
@@ -370,6 +370,7 @@ BOOL WINAPI	StretchBlt(HDC hdcDest,int nXOriginDest,int nYOriginDest,
 #define PC_EXPLICIT	0x02
 #define PC_NOCOLLAPSE	0x04
 
+/* note: must match MWPALENTRY structure*/
 typedef struct tagPALETTEENTRY {
 	BYTE	peRed;
 	BYTE	peGreen;

--- a/src/mwin/winfont.c
+++ b/src/mwin/winfont.c
@@ -66,7 +66,7 @@ CreateFontIndirect(CONST LOGFONT *lplf)
 	mwlf.lfOutPrecision = lplf->lfOutPrecision;
 	mwlf.lfClipPrecision = lplf->lfClipPrecision;
 	mwlf.lfQuality = lplf->lfQuality;
-	strncpy(mwlf.lfFaceName, lplf->lfFaceName, sizeof(mwlf.lfFaceName));
+	strzcpy(mwlf.lfFaceName, lplf->lfFaceName, sizeof(mwlf.lfFaceName));
 
 	family = lplf->lfPitchAndFamily & 0xf0;
 	switch(family) {
@@ -317,7 +317,7 @@ EnumFonts(
 		GdGetFontList(&lst, &n);
 		memset(&lf, 0, sizeof(lf));
 		for (i = 0; i < n; i++) {
-			strncpy(lf.lfFaceName, lst[i]->mwname, sizeof(lf.lfFaceName));
+			strzcpy(lf.lfFaceName, lst[i]->mwname, sizeof(lf.lfFaceName));
 			p = strrchr(lf.lfFaceName, '.');
 			if (p != NULL && strcasecmp(p, ".ttf") == 0)
 				*p = 0;

--- a/src/mwin/wingdi.c
+++ b/src/mwin/wingdi.c
@@ -2174,7 +2174,7 @@ UINT WINAPI RealizePalette(HDC hdc)
 {
 	PSD psd = hdc ? hdc->psd : &scrdev;
 
-	GdSetPalette(psd, 0, hdc->palette->palette.palNumEntries, hdc->palette->palette.palPalEntry);
+	GdSetPalette(psd, 0, hdc->palette->palette.palNumEntries, (MWPALENTRY *)&hdc->palette->palette.palPalEntry);
 	return hdc->palette->palette.palNumEntries;
 }
 


### PR DESCRIPTION
This continues fixes identified by @djipi in #49.

Also fixes compiler warning introduced in #42.
