### PR TITLE
Update build for Emscripten v2.0.11

### DIFF
--- a/src/Configs/config.emscripten
+++ b/src/Configs/config.emscripten
@@ -227,7 +227,7 @@ HAVETEXTMODE             = N
 # SCREEN_DEPTH is bits per pixel, only used with MWPF_PALETTE palette mode
 ####################################################################
 SCREEN_PIXTYPE           = MWPF_TRUECOLORARGB
-#SCREEN_PIXTYPE           = MWPF_TRUECOLORABGR 
+#SCREEN_PIXTYPE           = MWPF_TRUECOLORABGR
 #SCREEN_PIXTYPE           = MWPF_TRUECOLOR565
 SCREEN_DEPTH             = 8
 

--- a/src/demos/Makefile-emscripten
+++ b/src/demos/Makefile-emscripten
@@ -1,7 +1,7 @@
 #
 # Link Microwindows EMSCRIPTEN demos Makefile
 # 
-# Execute with "make -f src/link-emscripten"
+# Execute with "make -f demos/Makefile-emscripten"
 # Run demos with ./emrun <appname>[.html]
 #
 # This may eventually be integrated into the demos/mwin and demos/nanox Makefiles
@@ -29,15 +29,17 @@ CFLAGS += -I$(MW_DIR_SRC)/nx11/X11-local
 LDFLAGS =
 
 CFLAGS += -s USE_SDL=2 -s USE_ZLIB=1 -s USE_FREETYPE=1 -s USE_LIBPNG=1
-LDFLAGS += -s EMTERPRETIFY=1 -s EMTERPRETIFY_ASYNC=1
-LDFLAGS += -s WASM=0
+LDFLAGS += -s ASYNCIFY -s WASM=1 --closure 1 -flto
 LDFLAGS += -s TOTAL_MEMORY=67108864
 LDFLAGS += -s ERROR_ON_UNDEFINED_SYMBOLS=0
 #LDFLAGS += -s ASSERTIONS=1
-#LDFLAGS += -s EMTERPRETIFY_ADVISE=1			# advise functions to whitelist
 
 # applications not following docs/EMSCRIPTEN.rules may have to add functions here
-WHITELIST = -s EMTERPRETIFY_WHITELIST='[ \
+#LDFLAGS += -s EMTERPRETIFY=1 -s EMTERPRETIFY_ASYNC=1
+#LDFLAGS += -s WASM=0
+#LDFLAGS += -s EMTERPRETIFY_ADVISE=1			# advise functions to whitelist
+#EMTERPFILE = -s EMTERPRETIFY_FILE=$(patsubst %.html,%,$@).binary
+#WHITELIST = -s EMTERPRETIFY_WHITELIST='[ \
 				"_invoke_WinMain_Start", "_WinMain", "_MwSelect", "_GdDelay", \
 				"_GetMessage", "_PeekMessage", "_chkPaintMsg", \
 				"_main", "_GsSelect", "_GrDelay", "_GrFlush", \
@@ -119,12 +121,12 @@ all: $(MWINDEMOS) $(NANOXDEMOS) $(NANOXFONTDEMOS) $(SPECIAL_LINKED_DEMOS) $(NX11
 ######## MWIN DEMOS ########
 $(MWINDEMOS): $(MW_DIR_BIN)/%.html: $(MW_DIR_SRC)/demos/mwin/%.c
 	@echo "Linking $(patsubst $(MW_DIR_BIN)/%,%,$@) ..."
-	$(CC) $(COMPILEARGS) -o $@ $< $(MWINLIBS) -s EMTERPRETIFY_FILE=$(patsubst %.html,%,$@).binary
+	$(CC) $(COMPILEARGS) -o $@ $< $(MWINLIBS) $(EMTERPFILE)
 
 ######## MWIN SPECIAL LINKED DEMOS ########
 $(MWDVETEST): $(MW_DIR_BIN)/%.html: $(MW_DIR_SRC)/demos/mwin/%.c
 	@echo "Linking $(patsubst $(MW_DIR_BIN)/%,%,$@) ..."
-	$(CC) $(COMPILEARGS_FULL_EMTERPRETIFY) -o $@ $< $(MWINLIBS) $(MWDVETESTPRELOAD) $(DEMOFONTS) -s EMTERPRETIFY_FILE=$(patsubst %.html,%,$@).binary
+	$(CC) $(COMPILEARGS_FULL_EMTERPRETIFY) -o $@ $< $(MWINLIBS) $(MWDVETESTPRELOAD) $(DEMOFONTS) $(EMTERPFILE)
 
 # List of images for the mwmine demo.
 MINEIMAGES := \
@@ -137,28 +139,28 @@ MINEIMAGES := \
 
 $(MWMINE): $(MW_DIR_BIN)/%.html: $(MW_DIR_SRC)/demos/mwin/%.c
 	@echo "Linking $(patsubst $(MW_DIR_BIN)/%,%,$@) ..."
-	$(CC) $(COMPILEARGS) -o $@ $< $(MINEIMAGES) $(MWINLIBS) -s EMTERPRETIFY_FILE=$(patsubst %.html,%,$@).binary
+	$(CC) $(COMPILEARGS) -o $@ $< $(MINEIMAGES) $(MWINLIBS) $(EMTERPFILE)
 
 ######## NANOX DEMOS ########
 $(NANOXDEMOS): $(MW_DIR_BIN)/%.html: $(MW_DIR_SRC)/demos/nanox/%.c
 	@echo "Linking $(patsubst $(MW_DIR_BIN)/%,%,$@) ..."
-	$(CC) $(COMPILEARGS) -o $@ $< $(NANOXLIBS) -s EMTERPRETIFY_FILE=$(patsubst %.html,%,$@).binary
+	$(CC) $(COMPILEARGS) -o $@ $< $(NANOXLIBS) $(EMTERPFILE)
 
 ######## NANOX FONT DEMOS ########
 $(NANOXFONTDEMOS): $(MW_DIR_BIN)/%.html: $(MW_DIR_SRC)/demos/nanox/%.c
 	@echo "Linking $(patsubst $(MW_DIR_BIN)/%,%,$@) ..."
-	$(CC) $(COMPILEARGS) -o $@ $< $(NANOXLIBS) $(DEMOFONTS) -s EMTERPRETIFY_FILE=$(patsubst %.html,%,$@).binary
+	$(CC) $(COMPILEARGS) -o $@ $< $(NANOXLIBS) $(DEMOFONTS) $(EMTERPFILE)
 
 ######## NANOX SPECIAL LINKED DEMOS ########
 $(DEMOCOMPOSITE): $(MW_DIR_BIN)/%.html: $(MW_DIR_SRC)/demos/nanox/%.c
 	@echo "Linking $(patsubst $(MW_DIR_BIN)/%,%,$@) ..."
-	$(CC) $(COMPILEARGS) -o $@ $< $(NANOXLIBS) $(DEMOFONTS) $(DEMOCOMPOSITEPRELOAD) -s EMTERPRETIFY_FILE=$(patsubst %.html,%,$@).binary
+	$(CC) $(COMPILEARGS) -o $@ $< $(NANOXLIBS) $(DEMOFONTS) $(DEMOCOMPOSITEPRELOAD) $(EMTERPFILE)
 
 $(DEMOAGG): $(MW_DIR_BIN)/%.html: $(MW_DIR_SRC)/demos/nanox/%.cpp
 	@echo "Linking $(patsubst $(MW_DIR_BIN)/%,%,$@) ..."
-	$(CC) $(COMPILEARGS) -o $@ $< demos/nanox/agglite.cpp $(NANOXLIBS) -s EMTERPRETIFY_FILE=$(patsubst %.html,%,$@).binary
+	$(CC) $(COMPILEARGS) -o $@ $< demos/nanox/agglite.cpp $(NANOXLIBS) $(EMTERPFILE)
 
 ######## NX11 DEMOS ########
 $(NX11DEMOS): $(MW_DIR_BIN)/%.html: $(MW_DIR_SRC)/contrib/nx11-test/%.c
 	@echo "Linking $(patsubst $(MW_DIR_BIN)/%,%,$@) ..."
-	$(CC) $(COMPILEARGS) -o $@ $< $(NX11LIBS) -s EMTERPRETIFY_FILE=$(patsubst %.html,%,$@).binary
+	$(CC) $(COMPILEARGS) -o $@ $< $(NX11LIBS) $(EMTERPFILE)

--- a/src/emrun
+++ b/src/emrun
@@ -32,4 +32,4 @@ then
 fi
 
 # Run EMSCRIPTEN application in browser
-emrun --no_emrun_detect $application.html
+emrun --no_emrun_detect --serve_after_close $application.html

--- a/src/make-emscripten
+++ b/src/make-emscripten
@@ -12,5 +12,5 @@ fi
 make
 
 # link libraries using external makefile
-make -f demos/Makefile-emscripten-mwapp
+#make -f demos/Makefile-emscripten-mwapp
 make -f demos/Makefile-emscripten

--- a/src/nx11/stub.c
+++ b/src/nx11/stub.c
@@ -148,7 +148,7 @@ int XVaCreateNestedList() { DPRINTF("XVaCreateNestedList called\n"); return 0; }
 int _XVIDtoVisual() { DPRINTF("_XVIDtoVisual called\n"); return 0; } 
 int XInstallColormap() { DPRINTF("XInstallColormap called\n"); return 0; } 
 int XReconfigureWMWindow() { DPRINTF("XReconfigureWMWindow called\n"); return 0; } 
-int XSetWindowColormap() { DPRINTF("XSetWindowColormap called\n"); return 0; } 
+int XSetWindowColormap(int i, int j, int k) { DPRINTF("XSetWindowColormap called\n"); return 0; }
 int XUninstallColormap() { DPRINTF("XUninstallColormap called\n"); return 0; } 
 //int XConfigureWindow() { DPRINTF("XConfigureWindow called\n"); return 0; } 
 int XForceScreenSaver() { DPRINTF("XForceScreenSaver called\n"); return 0; } 
@@ -160,7 +160,7 @@ int XGetWMColormapWindows() { DPRINTF("XGetWMColormapWindows called\n"); return 
 int XListHosts() { DPRINTF("XListHosts called\n"); return 0; } 
 //int XSetClassHint() { DPRINTF("XSetClassHint called\n"); return 0; } 
 int XSetCommand() { DPRINTF("XSetCommand called\n"); return 11; } /* 11 = BADALLOC */
-int XSetWindowBorderPixmap() { DPRINTF("XSetWindowBorderPixmap called\n"); return 0; } 
+int XSetWindowBorderPixmap(int i, int j, int k) { DPRINTF("XSetWindowBorderPixmap called\n"); return 0; }
 //int XSetWMClientMachine() { DPRINTF("XSetWMClientMachine called\n"); return 0; } 
 int XSetWMColormapWindows() { DPRINTF("XSetWMColormapWindows called\n"); return 0; } 
 int XStoreColor() { DPRINTF("XStoreColor called\n"); return 0; }


### PR DESCRIPTION
Removes EMTERPRIFY options and uses only WASM code and ASYNC=1, as older EMTERPRETER has been removed from EMSCRIPTEN.

All Win32 and Nano-X programs now build and operate correctly with latest Emscripten version.

Fixes race problem with web pages not completing .js or .data file loads before program exit.

Should fix #37 and probably #55.

To build the EMSCRIPTEN port (builds all demos and runs demo-aafont):
```
cp Configs/config.emscripten config
./make-emscripten
./emrun demo-aafont
```
