### PR TITLE
First pass at IBM CGA and PC-98 screen drivers

### DIFF
--- a/src/Makefile.elks
+++ b/src/Makefile.elks
@@ -10,6 +10,11 @@ include $(BASEDIR)/Makefile-rules
 # Uncomment the following line to link nano-X applications with the server.
 #LINK_APP_INTO_SERVER=1
 
+# Modify the following lines to build IBM/VGA, IBM/CGA or PC98 drivers
+CONFIG_ARCH_IBMPC=y
+CONFIG_HW_VGA=n
+CONFIG_ARCH_PC98=n
+
 # remove any -mregparmcall as ASM files need cdecl calling convention
 CFLAGS := $(filter-out -mregparmcall, $(CFLAGS))
 CFLAGS += -DELKS=1 -DUNIX=1 -DNANOWM=1 -DNDEBUG=1
@@ -19,26 +24,26 @@ CFLAGS += -Wno-unused-variable -Wno-unused-but-set-variable
 CFLAGS += -Wno-missing-field-initializers
 AR = ia16-elf-ar
 
-# mouse and kbd drivers
+# screen, mouse and kbd drivers
 ifeq ($(CONFIG_ARCH_PC98), y)
+DRIVERS += drivers/memplan4.o drivers/elksutilasm.o
 DRIVERS += drivers/mou_pc98.o drivers/kbd_tty.o
 DRIVERS += drivers/scr_pc98.o drivers/vgaplan4_pc98.o
-DRIVERS += drivers/ramfont.o drivers/X6x13.o
-DRIVERS += drivers/memplan4.o drivers/elksutilasm.o
+#DRIVERS += drivers/ramfont.o
 endif
 
-#ifeq ($(CONFIG_ARCH_IBMPC), y)
+ifeq ($(CONFIG_ARCH_IBMPC), y)
 DRIVERS += drivers/memplan4.o drivers/elksutilasm.o
 DRIVERS += drivers/mou_ser.o drivers/kbd_tty.o
 
-#ifeq ($(CONFIG_HW_VGA), y)
+ifeq ($(CONFIG_HW_VGA), y)
 DRIVERS += drivers/scr_vga.o drivers/vgaplan4.o
 #DRIVERS += elksdrivers/romfont.o
-#else
-#DRIVERS += drivers/scr_cga.o drivers/vgaplan4_cga.o
+else
+DRIVERS += drivers/scr_cga.o drivers/vgaplan4_cga.o
 #DRIVERS += drivers/ramfont.o
-#endif
-#endif
+endif
+endif
 
 # C/ASM VGA driver (BCC)
 #DRIVERS += drivers/elkplan4.o drivers/elksutil.o

--- a/src/drivers/mou_pc98.c
+++ b/src/drivers/mou_pc98.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 1999 Greg Haerr <greg@censoft.com>
+ * Portions Copyright (c) 1991 David I. Bell
+ * Permission is granted to use, distribute, or modify this source,
+ * provided that this copyright notice remains intact.
+ *
+ * PC-98 Bus Mouse Driver
+ * This driver is created and modified, based on mou_ser.c
+ * T. Yamada 2023
+ * 
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include "device.h"
+
+extern int  inportb(int port);
+extern void outportb(int port,unsigned char data);
+
+#define SCALE       3   /* default scaling factor for acceleration */
+#define THRESH      5   /* default threshhold for acceleration */
+
+/* default settings*/
+#define MOUSE_PORT  "use"   /* default */
+
+/* values in the bytes returned by the mouse for the buttons*/
+#define PC98_LEFT_BUTTON    0x80
+#define PC98_RIGHT_BUTTON   0x20
+
+/* I/O address */
+#define PC98_MOUSE_I_ADDR        0x7FD9
+#define PC98_MOUSE_O_ADDR        0x7FDD
+#define PC98_MOUSE_CONTROL_ADDR  0x7FDF
+
+/* I/O bits */
+#define PC98_O_HC   0x80 /* counter is hold and cleared */
+#define PC98_O_X_L  0x00 /* X LSB 4bits are selected */
+#define PC98_O_X_M  0x20 /* X MSB 4bits are selected */
+#define PC98_O_Y_L  0x40 /* Y LSB 4bits are selected */
+#define PC98_O_Y_M  0x60 /* Y MSB 4bits are selected */
+#define PC98_O_C    0x93 /* countrol register value */
+
+/* local data*/
+static int       buttons;        /* current mouse buttons pressed */
+static int       buttons_before; /* previous mouse buttons pressed */
+static int       availbuttons;   /* which buttons are available */
+static MWCOORD   x_now;          /* current x counter value */
+static MWCOORD   y_now;          /* current y counter value */
+
+static int      left;       /* because the button values change */
+static int      right;      /* between mice, the buttons are redefined */
+
+/* local routines*/
+static int      MOU_Open(MOUSEDEVICE *pmd);
+static void     MOU_Close(void);
+static int   MOU_GetButtonInfo(void);
+static void     MOU_GetDefaultAccel(int *pscale,int *pthresh);
+static int      MOU_Read(MWCOORD *dx, MWCOORD *dy, MWCOORD *dz, int *bptr);
+static int      MOU_Poll(void);
+
+MOUSEDEVICE mousedev = {
+    MOU_Open,
+    MOU_Close,
+    MOU_GetButtonInfo,
+    MOU_GetDefaultAccel,
+    MOU_Read,
+    MOU_Poll
+};
+
+/*
+ * Open up the mouse device.
+ */
+static int
+MOU_Open(MOUSEDEVICE *pmd)
+{
+    char    *port;
+
+    /* Control Register for 8255A */
+    /* Port A input, Port B input, Port C MSB output, Port C LSB input */
+    outportb(PC98_MOUSE_CONTROL_ADDR, PC98_O_C);
+
+    if (!(port = getenv("MOUSE_PORT")))
+        port = MOUSE_PORT;
+
+    if (!strcmp(port, "none"))
+        return -2;      /* no mouse */
+
+    /* set button bits and parse procedure*/
+    left = PC98_LEFT_BUTTON;
+    right = PC98_RIGHT_BUTTON;
+
+    /* initialize data*/
+    availbuttons = MWBUTTON_L | MWBUTTON_R;
+    buttons = 0;
+    buttons_before = 0;
+
+    return -3;
+}
+
+/*
+ * Close the mouse device.
+ */
+static void
+MOU_Close(void)
+{
+}
+
+/*
+ * Get mouse buttons supported
+ */
+static int
+MOU_GetButtonInfo(void)
+{
+    return availbuttons;
+}
+
+/*
+ * Get default mouse acceleration settings
+ */
+static void
+MOU_GetDefaultAccel(int *pscale,int *pthresh)
+{
+    *pscale = SCALE;
+    *pthresh = THRESH;
+}
+
+/*
+ * Attempt to read bytes from the mouse and interpret them.
+ * When a new state is read, the current buttons and x and y deltas
+ * are returned. This routine does not block.
+ */
+static int
+MOU_Read(MWCOORD *dx, MWCOORD *dy, MWCOORD *dz, int *bptr)
+{
+    int b;
+
+    /*
+     * If the X, Y values are greater than 127,
+     * then the delta would be negative.
+     */
+    if (x_now > 127)
+        *dx = x_now - 256;
+    else
+        *dx = x_now;
+
+    if (y_now > 127)
+        *dy = y_now - 256;
+    else
+        *dy = y_now;
+
+    *dz = 0;
+
+    /* Read button again in case Poll is not called */
+    buttons = (inportb(PC98_MOUSE_I_ADDR) & 0xE0) ^ 0xE0;
+    buttons_before = buttons;
+
+    b = 0;
+    if (buttons & left)
+        b |= MWBUTTON_L;
+    if (buttons & right)
+        b |= MWBUTTON_R;
+    *bptr = b;
+
+    return 1;
+}
+
+static int
+MOU_Poll(void)
+{
+    /*
+     * The counter for x, y values are cleared every time.
+     * If the x, y values are not equal to zero or
+     * button states have changed then return 1.
+     */
+    outportb(PC98_MOUSE_O_ADDR, (PC98_O_HC | PC98_O_X_L)); // X LSB 4bits
+    x_now = inportb(PC98_MOUSE_I_ADDR) & 0xF;
+
+    outportb(PC98_MOUSE_O_ADDR, (PC98_O_HC | PC98_O_X_M)); // X MSB 4bits
+    x_now += (inportb(PC98_MOUSE_I_ADDR) & 0xF) << 4;
+
+    outportb(PC98_MOUSE_O_ADDR, (PC98_O_HC | PC98_O_Y_L)); // Y LSB 4bits
+    y_now = inportb(PC98_MOUSE_I_ADDR) & 0xF;
+
+    outportb(PC98_MOUSE_O_ADDR, (PC98_O_HC | PC98_O_Y_M)); // Y MSB 4bits
+    y_now += (inportb(PC98_MOUSE_I_ADDR) & 0xF) << 4;
+
+    buttons = (inportb(PC98_MOUSE_I_ADDR) & 0xE0) ^ 0xE0;
+
+    outportb(PC98_MOUSE_O_ADDR, 0x00); // Clear HC
+
+    if (x_now || y_now || (buttons != buttons_before)) {
+        buttons_before = buttons;
+        return 1;
+    }
+    else {
+        return 0;
+    }
+}

--- a/src/drivers/scr_cga.c
+++ b/src/drivers/scr_cga.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 1999 Greg Haerr <greg@censoft.com>
+ *
+ * CGA Screen Driver
+ * This driver is created and modifed, based on EGA/VGA driver.
+ * T. Yamada 2024
+ *
+ * 	For CGA, 2 color, 640x200 resolution
+ * 	This driver uses bios for graphical setting.
+ *
+ * 	This file itself doesn't know about any planar or packed arrangement, relying soley
+ * 	on routines in vgaplan4_cga.c for drawing.
+ */
+
+#include <linuxmt/ntty.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "device.h"
+#include "vgaplan4.h"
+#include "genmem.h"
+#if ROMFONT
+#include "romfont.h"
+#else
+#include "genfont.h"
+#endif
+
+#define _MK_FP(seg,off) ((void __far *)((((unsigned long)(seg)) << 16) | (off)))
+
+/* CGA driver entry points*/
+static PSD  CGA_open(PSD psd);
+static void CGA_close(PSD psd);
+static void CGA_getscreeninfo(PSD psd, PMWSCREENINFO psi);;
+static void CGA_setpalette(PSD psd,int first,int count, MWPALENTRY *pal);
+
+SCREENDEVICE	scrdev = {
+    0, 0, 0, 0, 0, 0, 0, NULL, 0, NULL, 0, 0, 0, 0, 0, 0,
+#if ROMFONT
+        pcrom_fonts,
+#else
+        gen_fonts,
+#endif
+        CGA_open,
+        CGA_close,
+        CGA_setpalette,
+        CGA_getscreeninfo,
+        gen_allocatememgc,
+        gen_mapmemgc,
+        gen_freememgc,
+        0,                      /* gen_setportrait*/
+        NULL,                   /* PreSelect*/
+};
+
+/* operating mode*/
+static MWBOOL MONOMODE = FALSE;	/* monochrome mode*/
+
+/* int10 functions*/
+#define FNGR640x200	0x0006	/* function for graphics mode 640x200x2*/
+#define FNTEXT		0x0003	/* function for 80x25 text mode*/
+
+static PSD
+CGA_open(PSD psd)
+{
+	extern SUBDRIVER vgaplan4_none;
+
+	/* setup operating mode from environment variable*/
+	if(getenv("MONOMODE"))
+		MONOMODE = TRUE;
+	else MONOMODE = FALSE;
+
+	int10(FNGR640x200, 0);
+
+	/* init driver variables depending on cga mode*/
+	psd->xres = psd->xvirtres = 640;
+	psd->yres = psd->yvirtres = 200;
+	psd->planes = 1;
+	psd->pixtype = MWPF_PALETTE;
+	psd->flags = PSF_SCREEN;
+	if (MONOMODE) {
+		psd->bpp = 1;
+		psd->ncolors = 2;
+	} else {
+		psd->bpp = 4;           /* color applications */
+		psd->ncolors = 16;
+	}
+    set_subdriver(psd, &vgaplan4_none);
+
+	cga_init(psd);              /* init planes driver (sets psd->linelen)*/
+
+#if ROMFONT
+	pcrom_init(psd);            /* init pc rom font routines*/
+#endif
+	return psd;
+}
+
+static void
+CGA_close(PSD psd)
+{
+	int10(FNTEXT, 0);           /* init bios 80x25 text mode*/
+}
+
+static void
+CGA_getscreeninfo(PSD psd, PMWSCREENINFO psi)
+{
+	psi->rows = psd->yvirtres;
+	psi->cols = psd->xvirtres;
+	psi->planes = psd->planes;
+	psi->bpp = psd->bpp;
+    psd->data_format = psd->data_format;
+	psi->ncolors = psd->ncolors;
+	psi->pixtype = psd->pixtype;
+	psi->fonts = NUMBER_FONTS;
+
+	/* 640x200 */
+	psi->xdpcm = 27;	/* assumes screen width of 24 cm*/
+	psi->ydpcm = 11;	/* assumes screen height of 18 cm*/
+}
+
+static void
+CGA_setpalette(PSD psd,int first,int count, MWPALENTRY *pal)
+{
+	/* not yet implemented, std 16 color palette assumed*/
+}

--- a/src/drivers/scr_pc98.c
+++ b/src/drivers/scr_pc98.c
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 1999 Greg Haerr <greg@censoft.com>
+ *
+ * PC-98 16 color 4 planes Screen Driver
+ * This driver is created and modifed, based on EGA/VGA driver.
+ * T. Yamada 2022
+ *
+ * 	For PC-98, 640x400 resolution
+ * 	This driver uses LIO for graphical setting.
+ *
+ * 	This file itself doesn't know about any planar or packed arrangement, relying soley
+ * 	on routines in vgaplan4_pc98.c for drawing.
+ */
+
+#include <linuxmt/ntty.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "device.h"
+#include "vgaplan4.h"
+#include "genmem.h"
+#include "fb.h"
+#if ROMFONT
+#include "romfont.h"
+#else
+#include "genfont.h"
+#endif
+
+#define LIOSEG      0xF990  /* ROM Segment for LIO */
+#define LIOINT      0xA0    /* Starting LIO interrupt number */
+#define LIO_M_SIZE  5200
+
+#define _MK_FP(seg,off) ((void __far *)((((unsigned long)(seg)) << 16) | (off)))
+
+/* PC98 driver entry points*/
+static PSD  PC98_open(PSD psd);
+static void PC98_close(PSD psd);
+static void PC98_getscreeninfo(PSD psd, PMWSCREENINFO psi);;
+static void PC98_setpalette(PSD psd,int first,int count, MWPALENTRY *pal);
+
+SCREENDEVICE	scrdev = {
+    0, 0, 0, 0, 0, 0, 0, NULL, 0, NULL, 0, 0, 0, 0, 0, 0,
+#if ROMFONT
+        pcrom_fonts,
+#else
+        gen_fonts,
+#endif
+        PC98_open,
+        PC98_close,
+        PC98_setpalette,
+        PC98_getscreeninfo,
+        gen_allocatememgc,
+        gen_mapmemgc,
+        gen_freememgc,
+        0,                      /* gen_setportrait*/
+        NULL,                   /* PreSelect*/
+};
+
+void int_A0(unsigned int l_seg)
+{
+    __asm__ volatile ("push %ds;"
+                      "push %es;"
+                      "push %bp;"
+                      "push %si;"
+                      "push %di;");
+    __asm__ volatile ("mov %0,%%ds;"
+                      "int $0xA0;"
+                      :
+                      :"a" (l_seg)
+                      :"memory", "cc");
+    __asm__ volatile ("pop %di;"
+                      "pop %si;"
+                      "pop %bp;"
+                      "pop %es;"
+                      "pop %ds;");
+}
+
+void int_A1(unsigned int l_seg)
+{
+    __asm__ volatile ("push %ds;"
+                      "push %es;"
+                      "push %bp;"
+                      "push %si;"
+                      "push %di;");
+    __asm__ volatile ("mov %0,%%ds;"
+                      "mov $0x0000,%%bx;"
+                      "int $0xA1;"
+                      :
+                      :"a" (l_seg)
+                      :"memory", "cc");
+    __asm__ volatile ("pop %di;"
+                      "pop %si;"
+                      "pop %bp;"
+                      "pop %es;"
+                      "pop %ds;");
+}
+
+void int_A2(unsigned int l_seg)
+{
+    __asm__ volatile ("push %ds;"
+                      "push %es;"
+                      "push %bp;"
+                      "push %si;"
+                      "push %di;");
+    __asm__ volatile ("mov %0,%%ds;"
+                      "mov $0x0000,%%bx;"
+                      "int $0xA2;"
+                      :
+                      :"a" (l_seg)
+                      :"memory", "cc");
+    __asm__ volatile ("pop %di;"
+                      "pop %si;"
+                      "pop %bp;"
+                      "pop %es;"
+                      "pop %ds;");
+}
+
+void int_A3(unsigned int l_seg)
+{
+    __asm__ volatile ("push %ds;"
+                      "push %es;"
+                      "push %bp;"
+                      "push %si;"
+                      "push %di;");
+    __asm__ volatile ("mov %0,%%ds;"
+                      "mov $0x0000,%%bx;"
+                      "int $0xA3;"
+                      :
+                      :"a" (l_seg)
+                      :"memory", "cc");
+    __asm__ volatile ("pop %di;"
+                      "pop %si;"
+                      "pop %bp;"
+                      "pop %es;"
+                      "pop %ds;");
+}
+
+static PSD
+PC98_open(PSD psd)
+{
+	unsigned char *lio_malloc;
+	unsigned char __far *lio_m;
+	unsigned int lio_m_seg;
+
+	unsigned long __far *intvec;
+	unsigned int __far *lioaddr;
+	unsigned int i;
+
+	unsigned int __far *tvram;
+
+	extern SUBDRIVER vgaplan4_none;
+
+	// Clear 80*25 words text vram starting from segment 0xA000
+	tvram = (unsigned int __far *) _MK_FP(0xA000,0);
+	for (i = 0; i < 2000; i++) {
+		*tvram = 0;
+		tvram++;
+	}
+
+	/* init driver variables for PC-98*/
+	psd->xres = psd->xvirtres = 640;
+	psd->yres = psd->yvirtres = 400;
+	psd->planes = 4;
+	psd->bpp = 4;
+	psd->ncolors = 16;
+	psd->pixtype = MWPF_PALETTE;
+	psd->flags = PSF_SCREEN;
+    set_subdriver(psd, &vgaplan4_none);
+
+	pc98_init(psd);             /* init planes driver (sets psd->addr and psd->linelen)*/
+
+	// Clear graphic vram
+	for (i = 0; i < psd->yres; i++)
+		pc98_drawhorzline(psd, 0, psd->xres, i, 0);
+
+    /* interrupt vector for INT 0xA0 */
+	intvec = (unsigned long __far *) _MK_FP(0, LIOINT<<2);
+    /* Starting Rom Address for INT 0xA0 handler */
+	lioaddr = (unsigned int __far *) _MK_FP(LIOSEG, 6);
+
+	// Set interrupt vector 0xA0 - 0xAF
+	for (i = 0; i < 16; i++) {
+		*intvec = (unsigned long) _MK_FP(LIOSEG, *lioaddr);
+		intvec++;
+		lioaddr += 2;
+	}
+
+	// Allocate memory for LIO
+	lio_malloc = malloc(LIO_M_SIZE);
+	lio_m = (unsigned char __far *) lio_malloc;
+
+	lio_m_seg = (unsigned int) ((((unsigned long) lio_m) >> 16) + ((((unsigned long) lio_m) & 0xFFFF) >> 4) + 1);
+	lio_m = (unsigned char __far *) (((unsigned long) lio_m_seg) << 16);
+
+	int_A0(lio_m_seg); // Init
+
+	lio_m[0] = 0x03; // Color 640x400
+	lio_m[1] = 0x00;
+	lio_m[2] = 0x00;
+	lio_m[3] = 0x01;
+	int_A1(lio_m_seg);
+
+	lio_m[0] = 0x00;
+	lio_m[1] = 0x00;
+	lio_m[2] = 0x00;
+	lio_m[3] = 0x00;
+	lio_m[4] = 0x7F; // 639
+	lio_m[5] = 0x02;
+	lio_m[6] = 0x8F; // 399
+	lio_m[7] = 0x01;
+	lio_m[8] = 0xFF;
+	lio_m[9] = 0xFF;
+	int_A2(lio_m_seg);
+
+	lio_m[0] = 0xFF;
+	lio_m[1] = 0xFF;
+	lio_m[2] = 0xFF;
+	lio_m[3] = 0x02; // 16 Color mode
+	int_A3(lio_m_seg);
+
+	free(lio_malloc);
+
+#if ROMFONT
+	pcrom_init(psd);            /* init pc rom font routines*/
+#endif
+
+	outb(0x0B,0x68); // Dot Access for font
+	return psd;
+}
+
+static void
+PC98_close(PSD psd)
+{
+	outb(0x0C,0xA2);   // GDC Stop
+	outb(0x0A,0x68);   // Code Access for font
+}
+
+static void
+PC98_getscreeninfo(PSD psd, PMWSCREENINFO psi)
+{
+    psi->rows = psd->yvirtres;
+    psi->cols = psd->xvirtres;
+    psi->planes = psd->planes;
+    psi->bpp = psd->bpp;
+    psi->data_format = psd->data_format;
+    psi->ncolors = psd->ncolors;
+    psi->pixtype = psd->pixtype;
+    psi->fonts = NUMBER_FONTS;
+
+	/* 640x400 */
+	psi->xdpcm = 27;	/* assumes screen width of 24 cm*/
+	psi->ydpcm = 27;	/* assumes screen height of 15 cm*/
+}
+
+static void
+PC98_setpalette(PSD psd,int first,int count, MWPALENTRY *pal)
+{
+	/* not yet implemented, std 16 color palette assumed*/
+}

--- a/src/drivers/scr_vga.c
+++ b/src/drivers/scr_vga.c
@@ -22,9 +22,8 @@
  * 	the portable VGA 4 planes 16 color driver, or asmplan4.s, which
  * 	is 8086 assembly language for speed.  This file itself
  * 	doesn't know about any planar or packed arrangement, relying soley
- * 	on the following external routines for all graphics drawing:
- * 		ega_init, ega_drawpixel, ega_readpixel,
- * 		ega_drawhorzline, ega_drawvertline
+ * 	on routines in vgaplan4.c for drawing:
+ * 		ega_init, ega_drawpixel, ega_readpixel, ega_drawhorzline, ega_drawvertline.
  *
  * 	All text/font drawing code is based on the above routines and
  * 	the included entry points for getting the ROM bitmap data.
@@ -63,13 +62,13 @@
 
 #include "device.h"
 #include "vgaplan4.h"
+#include "genmem.h"
+#include "fb.h"
 #if ROMFONT
 #include "romfont.h"
 #else
 #include "genfont.h"
 #endif
-#include "genmem.h"
-#include "fb.h"
 
 /* VGA driver entry points*/
 static PSD  VGA_open(PSD psd);
@@ -134,7 +133,7 @@ VGA_open(PSD psd)
 	psd->pixtype = MWPF_PALETTE;
 	psd->flags = PSF_SCREEN;
 	set_subdriver(psd, &vgaplan4_none);
-	ega_init(psd);		/* init planes driver (sets psd->addr and psd->pitch)*/
+	ega_init(psd);		/* init planes driver (sets psd->pitch)*/
 
 #if ROMFONT
 	pcrom_init(psd);	/* init pc rom font routines*/
@@ -142,7 +141,6 @@ VGA_open(PSD psd)
 #if 0
 	ROM_CHAR_HEIGHT = VGAMODE? 16: 14;
 #endif
-	/* FIXME: add palette code*/
 	return psd;
 }
 

--- a/src/drivers/vgaplan4.c
+++ b/src/drivers/vgaplan4.c
@@ -12,8 +12,8 @@
  *
  * This file is meant to compile under Linux, ELKS, and MSDOS
  * without changes.  Please try to keep it that way.
- * 
  */
+
 /*#define NDEBUG*/
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/drivers/vgaplan4.h
+++ b/src/drivers/vgaplan4.h
@@ -79,10 +79,9 @@ FARADDR		int10(int ax,int bx);
 
 /* portable C EGA/VGA planar-4 driver in vgaplan4.c/memplan4.c*/
 int		ega_init(PSD psd);
-void 		ega_drawpixel(PSD psd,MWCOORD x,MWCOORD y, MWPIXELVAL c);
-MWPIXELVAL 	ega_readpixel(PSD psd,MWCOORD x,MWCOORD y);
-void		ega_drawhorzline(PSD psd,MWCOORD x1,MWCOORD x2, MWCOORD y,MWPIXELVAL c);
-void		ega_drawvertline(PSD psd,MWCOORD x,MWCOORD y1, MWCOORD y2, MWPIXELVAL c);
+int		cga_init(PSD psd);
+int		pc98_init(PSD psd);
+void		pc98_drawhorzline(PSD psd,MWCOORD x1,MWCOORD x2, MWCOORD y,MWPIXELVAL c);
 #if HAVEBLIT
 void	 	ega_blit(PSD dstpsd, MWCOORD dstx, MWCOORD dsty, MWCOORD w,
 			MWCOORD h,PSD srcpsd,MWCOORD srcx,MWCOORD srcy,int op);

--- a/src/drivers/vgaplan4_cga.c
+++ b/src/drivers/vgaplan4_cga.c
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 1999 Greg Haerr <greg@censoft.com>
+ *
+ * 16 color 4 planes EGA/VGA Planar Video Driver for MicroWindows
+ * Portable C version
+ * Blitting enabled with #define HAVEBLIT in vgaplan4.h
+ *
+ * Based on BOGL - Ben's Own Graphics Library.
+ *   Written by Ben Pfaff <pfaffben@debian.org>.
+ *	 BOGL is licensed under the terms of the GNU General Public License
+ *
+ * In this driver, psd->pitch is line byte length, not line pixel length
+ *
+ */
+
+/* Modified for CGA
+ * T. Yamada 2024
+ */
+
+/*#define NDEBUG*/
+#include <assert.h>
+#include "device.h"
+#include "vgaplan4.h"
+#include "fb.h"
+#include "genmem.h"
+
+/* assumptions for speed: NOTE: psd is ignored in these routines*/
+#define SCREENBASE0 	MK_FP(0xb800, 0)
+#define SCREENBASE1 	MK_FP(0xba00, 0)
+#define BYTESPERLINE		80
+
+static FARADDR screenbase_table[2] = {
+	SCREENBASE0, SCREENBASE1
+};
+
+/* precalculated mask bits*/
+static unsigned char mask[8] = {
+	0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01
+};
+
+/* Init CGA controller, calc pitch */
+int
+cga_init(PSD psd)
+{
+	psd->pitch = BYTESPERLINE;
+	psd->addr = 0;		/* long ptr -> short on 16bit sys*/
+	psd->size = 0;
+	return 1;
+}
+
+/* draw a pixel at x,y of color c*/
+void
+cga_drawpixel(PSD psd, MWCOORD x,  MWCOORD y, MWPIXELVAL c)
+{
+	FARADDR dst;
+	assert (x >= 0 && x < psd->xres);
+	assert (y >= 0 && y < psd->yres);
+	assert (c >= 0 && c < psd->ncolors);
+
+	DRAWON;
+	if (y < psd->yres) {
+		dst = screenbase_table[y&1] + x / 8 + y / 2 * BYTESPERLINE;
+		if(gr_mode == MWROP_XOR) {
+			if  (c) {
+				PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x&7]));
+			}
+		} else {
+			if  (c) {
+				ORBYTE_FP (dst,mask[x&7]);
+			}
+		else {
+				ANDBYTE_FP (dst,~mask[x&7]);
+			}
+		}
+	}
+	DRAWOFF;
+}
+
+/* Return pixel value at x,y*/
+MWPIXELVAL
+cga_readpixel(PSD psd, MWCOORD x, MWCOORD y)
+{
+	FARADDR		src;
+	MWPIXELVAL	c = 0;
+
+	assert (x >= 0 && x < psd->xres);
+	assert (y >= 0 && y < psd->yres);
+
+	DRAWON;
+	src = screenbase_table[y&1] + x / 8 + y / 2 * BYTESPERLINE;
+	if(GETBYTE_FP(src) & mask[x&7])
+		c = 1;
+	DRAWOFF;
+	return c;
+}
+
+/* Draw horizontal line from x1,y to x2,y not including final point*/
+void
+cga_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y,
+	MWPIXELVAL c)
+{
+	FARADDR dst, last;
+	MWCOORD x1_ini = x1;
+
+	assert (x1 >= 0 && x1 < psd->xres);
+	assert (x2 >= 0 && x2 < psd->xres);
+	assert (x2 >= x1);
+	assert (y >= 0 && y < psd->yres);
+	assert (c >= 0 && c < psd->ncolors);
+
+	DRAWON;
+	if (y < psd->yres) {
+		/* OR/AND mode is not supported for CGA for now */
+		if(gr_mode == MWROP_COPY) {
+			x1 = x1_ini;
+			dst = screenbase_table[y&1] + x1 / 8 + y / 2 * BYTESPERLINE;
+			if (x1 / 8 == x2 / 8) {
+				while(x1 < x2) {
+					if  (c) {
+						ORBYTE_FP (dst,mask[x1&7]);
+					}
+					else {
+						ANDBYTE_FP (dst,~mask[x1&7]);
+					}
+					x1++;
+				}
+			} else {
+
+				while (x1 % 8) {
+					if  (c) {
+						ORBYTE_FP (dst,mask[x1&7]);
+					}
+					else {
+						ANDBYTE_FP (dst,~mask[x1&7]);
+					}
+					x1++;
+				}
+				if (x1_ini % 8)
+					dst++;
+
+				last = screenbase_table[y&1] + x2 / 8 + y / 2 * BYTESPERLINE;
+				while (dst < last) {
+					if  (c) {
+						PUTBYTE_FP(dst++, 255);
+					}
+					else {
+						PUTBYTE_FP(dst++, 0);
+					}
+				}
+
+				x1 = ((x2 >> 3) << 3);
+				while (x1 < x2) {
+					if  (c) {
+						ORBYTE_FP (dst,mask[x1&7]);
+					}
+					else {
+						ANDBYTE_FP (dst,~mask[x1&7]);
+					}
+					x1++;
+				}
+			}
+		} else if(gr_mode == MWROP_XOR) {
+			x1 = x1_ini;
+			dst = screenbase_table[y&1] + x1 / 8 + y / 2 * BYTESPERLINE;
+			if (x1 / 8 == x2 / 8) {
+				while(x1 < x2) {
+					if  (c) {
+						PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
+					}
+					x1++;
+				}
+			} else {
+
+				while (x1 % 8) {
+					if  (c) {
+						PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
+					}
+					x1++;
+				}
+				if (x1_ini % 8)
+				dst++;
+
+				last = screenbase_table[y&1] + x2 / 8 + y / 2 * BYTESPERLINE;
+				while (dst < last) {
+					if  (c) {
+						PUTBYTE_FP(dst,~GETBYTE_FP(dst));
+						dst++;
+					}
+				}
+
+				x1 = ((x2 >> 3) << 3);
+				while (x1 < x2) {
+					if  (c) {
+						PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
+					}
+					x1++;
+				}
+			}
+		} else {
+			/* slower method, draw pixel by pixel*/
+			while(x1 < x2) {
+				if  (c) {
+					ORBYTE_FP (screenbase_table[y&1] + x1 / 8 + y / 2 * BYTESPERLINE,mask[x1&7]);
+				}
+				else {
+					ANDBYTE_FP (screenbase_table[y&1] + x1 / 8 + y / 2 * BYTESPERLINE,~mask[x1&7]);
+				}
+				x1++;
+			}
+		}
+	}
+	DRAWOFF;
+}
+
+/* Draw a vertical line from x,y1 to x,y2 not including final point*/
+void
+cga_drawvertline(PSD psd, MWCOORD x,  MWCOORD y1,  MWCOORD y2, MWPIXELVAL c)
+{
+	FARADDR dst;
+	MWCOORD y = y1;
+
+	assert (x >= 0 && x < psd->xres);
+	assert (y1 >= 0 && y1 < psd->yres);
+	assert (y2 >= 0 && y2 < psd->yres);
+	assert (y2 >= y1);
+	assert (c >= 0 && c < psd->ncolors);
+
+	DRAWON;
+	if(gr_mode == MWROP_XOR) {
+		while (y < y2 && y < psd->yres) {
+			dst = screenbase_table[y&1] + x / 8 + y / 2 * BYTESPERLINE;
+			if  (c) {
+				PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x&7]));
+			}
+			y++;
+		}
+	} else {
+		while (y < y2 && y < psd->yres) {
+			dst = screenbase_table[y&1] + x / 8 + y / 2 * BYTESPERLINE;
+			if  (c) {
+				ORBYTE_FP (dst,mask[x&7]);
+			}
+			else {
+				ANDBYTE_FP (dst,~mask[x&7]);
+			}
+			y++;
+		}
+	}
+	DRAWOFF;
+}
+
+SUBDRIVER vgaplan4_none = {
+    cga_drawpixel,
+    cga_readpixel,
+    cga_drawhorzline,
+    cga_drawvertline,
+    gen_fillrect,
+    ega_blit,
+    NULL,       /* FrameBlit*/
+    NULL,       /* FrameStretchBlit*/
+    0, //linear4_convblit_copy_mask_mono_byte_msb,
+    NULL,       /* BlitCopyMaskMonoByteLSB*/
+    NULL,       /* BlitCopyMaskMonoWordMSB*/
+    NULL,       /* BlitBlendMaskAlphaByte*/
+    NULL,       /* BlitCopyRGBA8888*/
+    NULL,       /* BlitSrcOverRGBA8888*/
+    NULL        /* BlitCopyRGB888*/
+
+};
+
+PSUBDRIVER vgaplan4[4] = {
+    &vgaplan4_none,
+#if MW_FEATURE_PORTRAIT
+    NULL, NULL, NULL
+#endif
+};
+

--- a/src/drivers/vgaplan4_pc98.c
+++ b/src/drivers/vgaplan4_pc98.c
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 1999 Greg Haerr <greg@censoft.com>
+ *
+ * 16 color 4 planes EGA/VGA Planar Video Driver for MicroWindows
+ * Portable C version
+ * Blitting enabled with #define HAVEBLIT in vgaplan4.h
+ *
+ * Based on BOGL - Ben's Own Graphics Library.
+ *   Written by Ben Pfaff <pfaffben@debian.org>.
+ *	 BOGL is licensed under the terms of the GNU General Public License
+ *
+ * In this driver, psd->pitch is line byte length, not line pixel length
+ *
+ */
+
+/* Modified for PC-98
+ * T. Yamada 2022
+ */
+
+/*#define NDEBUG*/
+#include <assert.h>
+#include "device.h"
+#include "vgaplan4.h"
+#include "fb.h"
+#include "genmem.h"
+
+/* assumptions for speed: NOTE: psd is ignored in these routines*/
+#define SCREENBASE0 	MK_FP(0xa800, 0)
+#define SCREENBASE1 	MK_FP(0xb000, 0)
+#define SCREENBASE2 	MK_FP(0xb800, 0)
+#define SCREENBASE3 	MK_FP(0xe000, 0)
+#define BYTESPERLINE		80
+
+static FARADDR screenbase_table[4] = {
+	SCREENBASE0, SCREENBASE2, SCREENBASE1, SCREENBASE3
+};
+
+/* precalculated mask bits*/
+static unsigned char mask[8] = {
+	0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01
+};
+
+/* Init VGA controller, calc pitch and mmap size, return 0 on fail*/
+int
+pc98_init(PSD psd)
+{
+	psd->pitch = BYTESPERLINE;
+	psd->addr = 0;		/* long ptr -> short on 16bit sys*/
+	psd->size = 0;
+
+	return 1;
+}
+
+/* draw a pixel at x,y of color c*/
+void
+pc98_drawpixel(PSD psd, MWCOORD x,  MWCOORD y, MWPIXELVAL c)
+{
+	FARADDR dst;
+	int		plane;
+
+	assert (x >= 0 && x < psd->xres);
+	assert (y >= 0 && y < psd->yres);
+	assert (c >= 0 && c < psd->ncolors);
+
+	DRAWON;
+	if(gr_mode == MWROP_XOR) {
+		for(plane=0; plane<4; ++plane) {
+			dst = screenbase_table[plane] + x / 8 + y * BYTESPERLINE;
+			if  (c & (1 << plane)) {
+				PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x&7]));
+			}
+		}
+	} else {
+		for(plane=0; plane<4; ++plane) {
+			dst = screenbase_table[plane] + x / 8 + y * BYTESPERLINE;
+			if  (c & (1 << plane)) {
+				ORBYTE_FP (dst,mask[x&7]);
+			}
+			else {
+				ANDBYTE_FP (dst,~mask[x&7]);
+			}
+		}
+	}
+	DRAWOFF;
+}
+
+/* Return 4-bit pixel value at x,y*/
+MWPIXELVAL
+pc98_readpixel(PSD psd, MWCOORD x, MWCOORD y)
+{
+	FARADDR		src;
+	int		    plane;
+	MWPIXELVAL	c = 0;
+
+	assert (x >= 0 && x < psd->xres);
+	assert (y >= 0 && y < psd->yres);
+
+	DRAWON;
+	for(plane=0; plane<4; ++plane) {
+		src = screenbase_table[plane] + x / 8 + y * BYTESPERLINE;
+		if(GETBYTE_FP(src) & mask[x&7])
+			c |= 1 << plane;
+	}
+	DRAWOFF;
+	return c;
+}
+
+/* Draw horizontal line from x1,y to x2,y not including final point*/
+void
+pc98_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y, MWPIXELVAL c)
+{
+	FARADDR dst, last;
+	int		plane;
+	MWCOORD x1_ini = x1;
+
+	assert (x1 >= 0 && x1 < psd->xres);
+	assert (x2 >= 0 && x2 < psd->xres);
+	assert (x2 >= x1);
+	assert (y >= 0 && y < psd->yres);
+	assert (c >= 0 && c < psd->ncolors);
+
+	DRAWON;
+	/* OR/AND mode is not supported for PC-98 for now */
+	if(gr_mode == MWROP_COPY) {
+		for(plane=0; plane<4; ++plane) {
+			x1 = x1_ini;
+			dst = screenbase_table[plane] + x1 / 8 + y * BYTESPERLINE;
+			if (x1 / 8 == x2 / 8) {
+				while(x1 < x2) {
+					if  (c & (1 << plane)) {
+						ORBYTE_FP (dst,mask[x1&7]);
+					}
+					else {
+						ANDBYTE_FP (dst,~mask[x1&7]);
+					}
+					x1++;
+				}
+			} else {
+
+				while (x1 % 8) {
+					if  (c & (1 << plane)) {
+						ORBYTE_FP (dst,mask[x1&7]);
+					}
+					else {
+						ANDBYTE_FP (dst,~mask[x1&7]);
+					}
+					x1++;
+				}
+				if (x1_ini % 8)
+					dst++;
+
+				last = screenbase_table[plane] + x2 / 8 + y * BYTESPERLINE;
+				while (dst < last) {
+					if  (c & (1 << plane)) {
+						PUTBYTE_FP(dst++, 255);
+					}
+					else {
+						PUTBYTE_FP(dst++, 0);
+					}
+				}
+
+				x1 = ((x2 >> 3) << 3);
+				while (x1 < x2) {
+					if  (c & (1 << plane)) {
+						ORBYTE_FP (dst,mask[x1&7]);
+					}
+					else {
+						ANDBYTE_FP (dst,~mask[x1&7]);
+					}
+					x1++;
+				}
+			}
+		}
+	} else if(gr_mode == MWROP_XOR) {
+		for(plane=0; plane<4; ++plane) {
+			x1 = x1_ini;
+			dst = screenbase_table[plane] + x1 / 8 + y * BYTESPERLINE;
+			if (x1 / 8 == x2 / 8) {
+				while(x1 < x2) {
+					if  (c & (1 << plane)) {
+						PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
+					}
+					x1++;
+				}
+			} else {
+
+				while (x1 % 8) {
+					if  (c & (1 << plane)) {
+						PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
+					}
+					x1++;
+				}
+				if (x1_ini % 8)
+					dst++;
+
+				last = screenbase_table[plane] + x2 / 8 + y * BYTESPERLINE;
+				while (dst < last) {
+					if  (c & (1 << plane)) {
+						PUTBYTE_FP(dst,~GETBYTE_FP(dst));
+						dst++;
+					}
+				}
+
+				x1 = ((x2 >> 3) << 3);
+				while (x1 < x2) {
+					if  (c & (1 << plane)) {
+						PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
+					}
+					x1++;
+				}
+			}
+		}
+	} else {
+		/* slower method, draw pixel by pixel*/
+		while(x1 < x2) {
+			for(plane=0; plane<4; ++plane) {
+				if  (c & (1 << plane)) {
+					ORBYTE_FP (screenbase_table[plane] + x1 / 8 + y * BYTESPERLINE,mask[x1&7]);
+				}
+				else {
+					ANDBYTE_FP (screenbase_table[plane] + x1 / 8 + y * BYTESPERLINE,~mask[x1&7]);
+				}
+			}
+			x1++;
+		}
+	}
+	DRAWOFF;
+}
+
+/* Draw a vertical line from x,y1 to x,y2 not including final point*/
+void
+pc98_drawvertline(PSD psd, MWCOORD x,  MWCOORD y1,  MWCOORD y2, MWPIXELVAL c)
+{
+	FARADDR dst, last;
+	int		plane;
+
+	assert (x >= 0 && x < psd->xres);
+	assert (y1 >= 0 && y1 < psd->yres);
+	assert (y2 >= 0 && y2 < psd->yres);
+	assert (y2 >= y1);
+	assert (c >= 0 && c < psd->ncolors);
+
+	DRAWON;
+	if(gr_mode == MWROP_XOR) {
+		for(plane=0; plane<4; ++plane) {
+			dst = screenbase_table[plane] + x / 8 + y1 * BYTESPERLINE;
+			last = screenbase_table[plane] + x / 8 + y2 * BYTESPERLINE;
+			while (dst < last) {
+				if  (c & (1 << plane)) {
+					PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x&7]));
+				}
+				dst += BYTESPERLINE;
+			}
+		}
+	} else {
+		for(plane=0; plane<4; ++plane) {
+			dst = screenbase_table[plane] + x / 8 + y1 * BYTESPERLINE;
+			last = screenbase_table[plane] + x / 8 + y2 * BYTESPERLINE;
+			while (dst < last) {
+				if  (c & (1 << plane)) {
+					ORBYTE_FP (dst,mask[x&7]);
+				}
+				else {
+					ANDBYTE_FP (dst,~mask[x&7]);
+				}
+				dst += BYTESPERLINE;
+			}
+		}
+	}
+	DRAWOFF;
+}
+
+SUBDRIVER vgaplan4_none = {
+        pc98_drawpixel,
+        pc98_readpixel,
+        pc98_drawhorzline,
+        pc98_drawvertline,
+        gen_fillrect,
+        ega_blit,
+        NULL,       /* FrameBlit*/
+        NULL,       /* FrameStretchBlit*/
+        0, //linear4_convblit_copy_mask_mono_byte_msb,
+        NULL,       /* BlitCopyMaskMonoByteLSB*/
+        NULL,       /* BlitCopyMaskMonoWordMSB*/
+        NULL,       /* BlitBlendMaskAlphaByte*/
+        NULL,       /* BlitCopyRGBA8888*/
+        NULL,       /* BlitSrcOverRGBA8888*/
+        NULL        /* BlitCopyRGB888*/
+
+};
+
+PSUBDRIVER vgaplan4[4] = {
+        &vgaplan4_none,
+#if MW_FEATURE_PORTRAIT
+        NULL, NULL, NULL
+#endif
+};


### PR DESCRIPTION
All screen, mouse and keyboard drivers are converted for IBM/CGA and PC98 platforms and are compiling without warnings.

I haven't had time to test PC-98, but IBM CGA ran in black and white but the internal screen height/width was incorrect, as 640x480 is hard-coded for ELKS in include/mwconfig.h for the time being. I haven't thought of a way to configure that easily, we aren't using the standard "config" method but a simpler one to build - see below.

@tyama501, I tried to keep all of your original driver code for CGA and PC98 without modifications, but the new Nano-X driver format is quite a bit different. I think we are close! :)

In order to build, the following lines in Makefile.elks needs to be edited as desired:
```
# Modify the following lines to build IBM/VGA, IBM/CGA or PC98 drivers
CONFIG_ARCH_IBMPC=y
CONFIG_HW_VGA=n
CONFIG_ARCH_PC98=n
```
and then run 
```
make clean
make -f Makefile.elks clean
make -f Makefile.elks all
```