### PR TITLE
Fixups for ELKS CGA, window manager window placement, cleanup

### DIFF
--- a/src/demos/nanox/npanel.c
+++ b/src/demos/nanox/npanel.c
@@ -52,24 +52,21 @@ static void do_buttonup(GR_EVENT_BUTTON *ep);
 static void do_update(GR_EVENT_UPDATE *ep);
 static void do_mouse(GR_EVENT_MOUSE *ep);
 
+#if ELKS
+#define PATH    "./"
+#else
+#define PATH    "bin/"
+#endif
+
 struct app_info {
 	char		app_id[10];
 	char		app_path[64];
 } Apps[] = {
-#if ELKS
-	{"clock", "./nxclock"},
-	{"term", "./nxterm"},
-	{"tetris", "./nxtetris"},
-	{"world", "./nxworld"},
-	{"landmine", "./nxlandmine"},
-	{"panel", "./nxpanel"},
-#else
-	{"clock", "bin/nxclock"},
-	{"term", "bin/nterm"},
-	{"demo", "bin/demo"},
-	{"demo2", "bin/demo2"},
-	{"ntest", "bin/ntest"},
-#endif
+	{"clock",   PATH "nxclock"},
+	{"term",    PATH "nxterm"},
+	{"tetris",  PATH "nxtetris"},
+	{"world",   PATH "nxworld"},
+	{"landmine",PATH "nxlandmine"},
 	{"", ""}
 };
 

--- a/src/demos/nanox/npanel.c
+++ b/src/demos/nanox/npanel.c
@@ -9,7 +9,8 @@
    Unfortunately since outline moves are not supported yet, the only
    alternative is "invisible" moving.
 */ 
-#define SHOW_WINDOW_MOTION
+#define WINDOW_MANAGER      0
+#define SHOW_WINDOW_MOTION  1
 
 /*
    Define this if you want the mouse pointer to become bell shaped when over
@@ -130,10 +131,9 @@ main(int argc,char **argv)
 
 	GrGetGCTextSize(gc, "A", 1, GR_TFASCII, &fwidth, &fheight, &fbase);
 	width = fwidth * 8 + 4;
-	height = (fheight) * num_apps + 4;
+	height = fheight * num_apps + 4;
 
-	w1 = GrNewWindow(GR_ROOT_WINDOW_ID, 5, 5, width,
-		height, 1, WHITE, BLACK);
+	w1 = GrNewWindow(GR_ROOT_WINDOW_ID, si.cols-width-10, 5, width, height, 1, WHITE, BLACK);
 
 	GrSelectEvents(w1, GR_EVENT_MASK_EXPOSURE | GR_EVENT_MASK_BUTTON_DOWN
 			| GR_EVENT_MASK_CLOSE_REQ);
@@ -203,7 +203,8 @@ static mwin * IsDecoration(GR_WINDOW_ID wid)
 	}
 	return NULL;
 }
-	
+
+#if WINDOW_MANAGER
 static mwin * FindWindow(GR_WINDOW_ID wid)
 {
 	mwin * mwp;
@@ -226,10 +227,12 @@ static mwin * NewWindow(GR_WINDOW_ID wid)
 	}
 	return mwp;
 }
+#endif
 
 static void
 do_update(GR_EVENT_UPDATE *ep)
 {
+#if WINDOW_MANAGER
 	mwin *	mwp;
 	mwin *	tmwp;
 	GR_WINDOW_INFO winfo;
@@ -248,11 +251,9 @@ do_update(GR_EVENT_UPDATE *ep)
 		mwp->y = ep->y - winfo.bordersize;
 		mwp->width = ep->width + 2 * winfo.bordersize;
 		GrMoveWindow(mwp->wid, mwp->x + winfo.bordersize,
-					mwp->y + DEC_HEIGHT +
-						2 * winfo.bordersize);
+			mwp->y + DEC_HEIGHT + 2 * winfo.bordersize);
 		mwp->fid = GrNewWindow(GR_ROOT_WINDOW_ID, mwp->x + 1,
-				mwp->y + 1, mwp->width - 2,
-				DEC_HEIGHT - 2, 1, BLUE, BLACK);
+			mwp->y + 1, mwp->width - 2, DEC_HEIGHT - 2, 1, BLUE, BLACK);
 		GrSelectEvents(mwp->fid, GR_EVENT_MASK_BUTTON_DOWN |
 			GR_EVENT_MASK_BUTTON_UP | GR_EVENT_MASK_MOUSE_POSITION);
 		GrMapWindow(mwp->fid);
@@ -273,8 +274,7 @@ do_update(GR_EVENT_UPDATE *ep)
 			case GR_UPDATE_MOVE:
 				GrGetWindowInfo(ep->wid, &winfo);
 				if ((ep->x == (mwp->x + winfo.bordersize)) &&
-					(ep->y == (mwp->y + winfo.bordersize
-							+ DEC_HEIGHT))) {
+					(ep->y == (mwp->y + winfo.bordersize + DEC_HEIGHT))) {
 					return;
 				}
 				mwp->x = ep->x - winfo.bordersize;
@@ -284,6 +284,7 @@ do_update(GR_EVENT_UPDATE *ep)
 				break;
 		}
 	}
+#endif
 }
 
 /*

--- a/src/demos/nanox/ntetris.c
+++ b/src/demos/nanox/ntetris.c
@@ -91,7 +91,9 @@
 #define random      rand
 #endif
 
-static int delay = 100;
+int WELL_HEIGHT = 28;		/* VGA */
+int WELL_VISIBLE_HEIGHT = 24;
+int delay = 100;
 
 void *my_malloc(size_t size)
 {
@@ -744,6 +746,10 @@ void init_game(nstate *state)
 		exit(1);
 	}
 	GrGetScreenInfo(&si);
+	if (si.rows <= 200) {		/* CGA */
+		WELL_HEIGHT = 18;
+		WELL_VISIBLE_HEIGHT = 16;
+	}
 
 	state->main_window = GrNewWindowEx(
 					GR_WM_PROPS_BORDER|GR_WM_PROPS_CAPTION|GR_WM_PROPS_CLOSEBOX,

--- a/src/demos/nanox/ntetris.h
+++ b/src/demos/nanox/ntetris.h
@@ -54,13 +54,8 @@
 #define TEXT_Y_POSITION 15
 #define TEXT2_Y_POSITION 30
 #define WELL_WIDTH 12
-#if defined(CONFIG_HW_VGA) || defined(CONFIG_ARCH_PC98)
-#define WELL_HEIGHT 28
-#define WELL_VISIBLE_HEIGHT 24
-#else
-#define WELL_HEIGHT 18
-#define WELL_VISIBLE_HEIGHT 16
-#endif
+#define MAX_WELL_HEIGHT 28
+extern int WELL_HEIGHT, WELL_VISIBLE_HEIGHT;
 #define WELL_NOTVISIBLE (WELL_HEIGHT - WELL_VISIBLE_HEIGHT)
 #define LEVEL_DIVISOR 500
 #ifdef __ECOS
@@ -162,7 +157,6 @@ struct ntetris_shape {
 typedef struct ntetris_shape shape;
 
 struct ntetris_state {
-	block blocks[2][WELL_HEIGHT][WELL_WIDTH];
 	int score;
 	int hiscore;
 	int fhiscore;
@@ -190,6 +184,7 @@ struct ntetris_state {
 	GR_GC_ID buttongcb;
 	GR_GC_ID wellgc;
 	GR_EVENT event;
+	block blocks[2][MAX_WELL_HEIGHT][WELL_WIDTH];
 	struct timeval timeout;
 };
 typedef struct ntetris_state nstate;

--- a/src/demos/nanox/world.c
+++ b/src/demos/nanox/world.c
@@ -157,12 +157,10 @@ main(int argc, char **argv)
 	GR_WM_PROPERTIES wmprops;
 	GR_SCREEN_INFO	si;
 
-#if 0   // FIXME this breaks GrOpen/connect below for unknown reasons!
 	if (access(MAPFILE, F_OK) < 0) {
-		GsError("Missing map file: %s\n", MAPFILE);
+		GrError("Missing map file: %s\n", MAPFILE);
 		return 1;
 	}
-#endif
 
 	if (GrOpen() < 0)
 		return 1;

--- a/src/engine/devimage.c
+++ b/src/engine/devimage.c
@@ -156,7 +156,7 @@ GdDrawImageFromBuffer(PSD psd, MWCOORD x, MWCOORD y, MWCOORD width,
 	}
 }
 
-#if HAVE_FILEIO
+#if (HAVE_FILEIO && MW_FEATURE_IMAGES)
 /**
  * Draw an image from a file.
  *
@@ -239,7 +239,7 @@ GdLoadImageFromFile(char *path, int flags)
 	close(fd);
 	return pmd;
 }
-#endif /* HAVE_FILEIO*/
+#endif /* (HAVE_FILEIO && MW_FEATURE_IMAGES)*/
 
 /*
  * Convert 8bpp palettized image to RGBA

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -80,7 +80,7 @@ typedef struct _mwscreendevice {
 	MWCOORD	xres;		/* X screen res (real) */
 	MWCOORD	yres;		/* Y screen res (real) */
 	unsigned int size;	/* size of memory allocated*/
-	int32_t	ncolors;	/* # screen colors*/
+	uint32_t	ncolors;/* # screen colors*/
 	int	pixtype;		/* format of pixel value*/
 
 	/* driver entry points*/

--- a/src/include/mwconfig.h
+++ b/src/include/mwconfig.h
@@ -31,13 +31,10 @@
 #endif
 
 #if ELKS
-#define SCREEN_WIDTH	640
-#define SCREEN_HEIGHT	480
-#define SCREEN_DEPTH    4
 #define USE_ALLOCA		0		/* =1 if alloca() is available*/
 #define HAVE_MMAP       0       /* =1 has mmap system call*/
 #define HAVE_SIGNAL		0		/* =1 has signal system call*/
-#define HAVE_FILEIO		1		/* =1 to include libc stdio and image reading routines*/
+#define HAVE_FILEIO		0		/* =1 to include libc stdio and image reading routines*/
 #define HAVE_BMP_SUPPORT 0		/* BMP image support*/
 #define HAVE_FNT_SUPPORT 0		/* Microwindows FNT font support*/
 #define HAVE_PCF_SUPPORT 0		/* PCF font support*/
@@ -49,6 +46,7 @@
 #define MW_FEATURE_INTL	0		/* =1 for dbcs and TEXTIP_EXTENDED font/encoding support*/
 #define MW_FEATURE_PORTRAIT 0	/* =1 for portrait support */
 #define MW_FEATURE_PALETTE 1	/* =1 for palette support*/
+#define SCREEN_DEPTH    4
 #define MW_FEATURE_AREAS 0	    /* =1 for GrArea, GrReadArea, GrStretchArea */
 #define MW_FEATURE_TINY 1	    /* =1 to drop various less-used features */
 #define MW_FEATURE_CLIENTDATA 0 /* =1 for copy/paste support */

--- a/src/include/mwtypes.h
+++ b/src/include/mwtypes.h
@@ -322,7 +322,7 @@ typedef struct {
 	int	 	planes;		/* hw # planes*/
 	int	 	bpp;		/* hw bpp*/
 	MWIMGDATFMT data_format;/* MWIF_ image data format*/
-	int32_t	ncolors;	/* hw number of colors supported*/
+	uint32_t	ncolors;/* hw number of colors supported*/
 	int 	fonts;		/* number of built-in fonts */
 	int 	buttons;	/* buttons which are implemented */
 	MWKEYMOD modifiers;	/* modifiers which are implemented */
@@ -1335,7 +1335,6 @@ typedef struct {
 #if MWPIXEL_FORMAT == MWPF_PALETTE
 //only required for compiling in palette pixel size, not supported in convblits
 //extern MWPALENTRY	gr_palette[256];
-//extern int32_t	gr_ncolors;
 //#define RGB2PIXEL(r,g,b)	GdFindNearestColor(gr_palette, gr_ncolors, MWRGB(r,g,b))
 #define RGB2PIXEL(r,g,b)	0
 #endif

--- a/src/nanox/client.c
+++ b/src/nanox/client.c
@@ -4631,6 +4631,7 @@ GrStretchArea(GR_DRAW_ID dstid, GR_GC_ID gc,
 }
 #endif
 
+#if !MW_FEATURE_TINY
 /**
  * Grab a key for a specific window.
  *
@@ -4705,7 +4706,6 @@ GrUngrabKey(GR_WINDOW_ID id, GR_KEY key)
 	UNLOCK(&nxGlobalLock);
 }
 
-#if !MW_FEATURE_TINY
 /**
  * This passes transform data to the mouse input engine. 
  *

--- a/src/nanox/srvfunc.c
+++ b/src/nanox/srvfunc.c
@@ -1741,6 +1741,7 @@ NewWindow(GR_WINDOW *pwp, GR_COORD x, GR_COORD y, GR_SIZE width, GR_SIZE height,
 {
 	GR_WINDOW	*wp;	/* new window*/
 	static int nextx = 10, nexty = 10;
+	static int firstx = 10, firsty = 10;
 
 	if (width <= 0 || height <= 0 || bordersize < 0) {
 		GsError(GR_ERROR_BAD_WINDOW_SIZE, 0);
@@ -1752,13 +1753,19 @@ NewWindow(GR_WINDOW *pwp, GR_COORD x, GR_COORD y, GR_SIZE width, GR_SIZE height,
 		GsError(GR_ERROR_MALLOC_FAILED, 0);
 		return NULL;
 	}
-	if (x < 0)
-		x = nextx, nextx += 100;
-	if (y < 0)
-		y = nexty, nexty += 100;
+	wp->psd = rootwp->psd;
+	if (x < 0 || y < 0) {
+		x = nextx;
+        if (x + width > wp->psd->xvirtres)
+            x = nextx = firstx += 10;
+		y = nexty;
+        if (y + height > wp->psd->yvirtres)
+            y = nexty = firsty += 10;
+        nextx += wp->psd->xvirtres / 8;
+        nexty += wp->psd->yvirtres / 8;
+    }
 
 	wp->id = nextid++;
-	wp->psd = rootwp->psd;
 	wp->parent = pwp;
 	wp->children = NULL;
 	wp->siblings = pwp->children;
@@ -4104,6 +4111,7 @@ GrSetWindowRegion(GR_WINDOW_ID wid, GR_REGION_ID rid, int type)
 #endif
 }
 
+#if !MW_FEATURE_TINY
 /**
  * This passes transform data to the mouse input engine.
  *
@@ -4233,6 +4241,7 @@ GrUngrabKey(GR_WINDOW_ID id, GR_KEY key)
 
 	SERVER_UNLOCK();
 }
+#endif
 
 /**
  * Ring Bell

--- a/src/nanox/srvnet.c
+++ b/src/nanox/srvnet.c
@@ -1595,7 +1595,8 @@ GrStretchAreaWrapper(void *r)
 static void
 GrGrabKeyWrapper(void *r)
 {
-        nxGrabKeyReq *req = r;
+#if !MW_FEATURE_TINY
+	nxGrabKeyReq *req = r;
 
 	if (req->type != GR_GRAB_MAX + 1) {   /* GrGrabKey */
 		int ret = GrGrabKey(req->wid, req->key, req->type);
@@ -1603,11 +1604,13 @@ GrGrabKeyWrapper(void *r)
 		GsWrite(current_fd, &ret, sizeof(ret));
 	} else
 		GrUngrabKey(req->wid, req->key);
+#endif
 }
 
 static void
 GrSetTransformWrapper(void *r) 
 {
+#if !MW_FEATURE_TINY
 	nxSetTransformReq *req = r;
 	GR_TRANSFORM trans;
 
@@ -1622,6 +1625,7 @@ GrSetTransformWrapper(void *r)
 		GrSetTransform(&trans);
 	} else
 		GrSetTransform(NULL);
+#endif
 }
 
 static void
@@ -1966,7 +1970,7 @@ GsDestroyClientResources(GR_CLIENT * client)
 	GR_TIMER      * tp, *ntp;
 #endif
 
-DPRINTF("Destroy client %d resources\n", client->id);
+	DPRINTF("Destroy client %d resources\n", client->id);
 	/* search window list, destroy windows owned by client*/
 again:
 	for(wp=listwp; wp; wp=nwp) {
@@ -1978,7 +1982,8 @@ again:
 		while (ecp) {
 			necp = ecp->next;
 			if (ecp->client == client) {
-DPRINTF( "  Destroy window %d eventclient mask %08x\n", wp->id, ecp->eventmask);
+				DPRINTF("  Destroy window %d eventclient mask %08x\n",
+					wp->id, ecp->eventmask);
 				if (ecp == wp->eventclients)
 					wp->eventclients = ecp->next;
 				else
@@ -1989,9 +1994,11 @@ DPRINTF( "  Destroy window %d eventclient mask %08x\n", wp->id, ecp->eventmask);
 			ecp = necp;
 		}
 		if (wp->owner == client) {
-DPRINTF("  Destroy window %d (client %d)\n", wp->id, wp->owner->id);
+			DPRINTF("  Destroy window %d (client %d)\n",
+				wp->id, wp->owner->id);
 			GrDestroyWindow(wp->id);
-			/* GsDestroyWindow frees client structs and changes the listwp window list, so start over*/
+			/* GsDestroyWindow frees client structs and changes the
+			   listwp window list, so start over*/
 			goto again;
 		}
 	}
@@ -2000,7 +2007,7 @@ DPRINTF("  Destroy window %d (client %d)\n", wp->id, wp->owner->id);
 	for(pp=listpp; pp; pp=npp) {
 		npp = pp->next;
 		if (pp->owner == client) {
-DPRINTF("  Destroy pixmap %d\n", pp->id);
+			DPRINTF("  Destroy pixmap %d\n", pp->id);
 			GrDestroyWindow(pp->id);
 		}
 	}
@@ -2009,7 +2016,7 @@ DPRINTF("  Destroy pixmap %d\n", pp->id);
 	for(gp=listgcp; gp; gp=ngp) {
 		ngp = gp->next;
 		if (gp->owner == client) {
-DPRINTF("  Destroy gc %d\n", gp->id);
+			DPRINTF("  Destroy gc %d\n", gp->id);
 			GrDestroyGC(gp->id);
 		}
 	}
@@ -2018,7 +2025,7 @@ DPRINTF("  Destroy gc %d\n", gp->id);
 	for(fp=listfontp; fp; fp=nfp) {
 		nfp = fp->next;
 		if (fp->owner == client) {
-DPRINTF("  Destroy font %d\n", fp->id);
+			DPRINTF("  Destroy font %d\n", fp->id);
 			GrDestroyFont(fp->id);
 		}
 	}
@@ -2028,7 +2035,7 @@ DPRINTF("  Destroy font %d\n", fp->id);
 	for(rp=listregionp; rp; rp=nrp) {
 		nrp = rp->next;
 		if (rp->owner == client) {
-DPRINTF("  Destroy region %d\n", rp->id);
+			DPRINTF("  Destroy region %d\n", rp->id);
 			GrDestroyRegion(rp->id);
 		}
 	}
@@ -2039,7 +2046,7 @@ DPRINTF("  Destroy region %d\n", rp->id);
 	for(tp=list_timer; tp; tp=ntp) {
 		ntp = tp->next;
 		if (tp->owner == client) {
-DPRINTF("  Destroy timer %d\n", tp->id);
+			DPRINTF("  Destroy timer %d\n", tp->id);
 			GrDestroyTimer(tp->id);
 		}
 	}
@@ -2049,24 +2056,26 @@ DPRINTF("  Destroy timer %d\n", tp->id);
 	for(cp=listcursorp; cp; cp=ncp) {
 		ncp = cp->next;
 		if (cp->owner == client) {
-DPRINTF("  Destroy cursor %d\n", cp->id);
+			DPRINTF("  Destroy cursor %d\n", cp->id);
 			GrDestroyCursor(cp->id);
 		}
 	}
 
+#if !MW_FEATURE_TINY
 	/* Free key grabs associated with client*/
 	for (kp=list_grabbed_keys; kp; kp = nkp) {
 		nkp = kp->next;
 		if (kp->owner == curclient) {
-DPRINTF("  Destroy grabkey %d,%d\n", kp->wid, kp->key);
+			DPRINTF("  Destroy grabkey %d,%d\n", kp->wid, kp->key);
 			GrUngrabKey(kp->wid, kp->key);
 		}
 	}
+#endif
 
 	/* Free events associated with client*/
 	evp = client->eventhead;
 	while (evp) {
-DPRINTF("  Destroy event %d\n", evp->event.type);
+		DPRINTF("  Destroy event %d\n", evp->event.type);
 		client->eventhead = evp->next;
 		evp->next = eventfree;
 		eventfree = evp;

--- a/src/nanox/wmclients.c
+++ b/src/nanox/wmclients.c
@@ -98,8 +98,8 @@ int wm_new_client_window(GR_WINDOW_ID wid)
 	}
 
 #if NO_AUTO_MOVE
-	x = winfo.x - xoffset;
-	y = winfo.y - yoffset;
+	x = MWABS(winfo.x - xoffset);
+	y = MWABS(winfo.y - yoffset);
 #else
 	/* determine x,y window location*/
 	if (style & GR_WM_PROPS_NOAUTOMOVE) {


### PR DESCRIPTION
Enhances automatic window placement x,y position (e.g. multiple nxclocks shown well).
Turns off unknown window manager behavior in npanel.
Cleans up support for CGA.
Adds automatic CGA app sizing in nxtetris.
More cleanups and reduction of executable/library sizes.

CGA driver now usable, but very ugly given monochrome mode and very limited screen space. Still useful for debugging screen sizes and VGA/PC-98 drivers.
