### PR TITLE
Speed up screen drivers, decrease caption height

### DIFF
--- a/src/Makefile.elks
+++ b/src/Makefile.elks
@@ -59,8 +59,7 @@ NANOX = nanox/srvmain.o nanox/srvfunc.o nanox/srvutil.o nanox/srvevent.o \
 NANOX += nanox/wmaction.o nanox/wmclients.o nanox/wmevents.o nanox/wmutil.o
 ENGINE = engine/devdraw.o engine/devmouse.o engine/devkbd.o engine/devclip1.o \
 	engine/devopen.o engine/devfont.o engine/devlist.o engine/devblit.o \
-    engine/devtimer.o \
-    engine/devpal1.o engine/devpal2.o engine/devpal4.o engine/devpal8.o
+    engine/devtimer.o engine/devpal1.o engine/devpal4.o
 
 ALL = lib/libnano-X.a nxdemos
 

--- a/src/demos/nanox/Makefile.elks
+++ b/src/demos/nanox/Makefile.elks
@@ -18,11 +18,12 @@ PROGS   = \
     $(BIN)nxclock   \
     $(BIN)nxtetris  \
     $(BIN)nxworld   \
-    $(BIN)npanel    \
+    $(BIN)nxpanel    \
     $(BIN)nxlandmine\
 
 notyet = \
     $(BIN)nxterm    \
+    $(BIN)nxlaunch\
 
 all: $(PROGS)
 	cp -p $(PROGS) $(TOPDIR)/elkscmd/rootfs_template/root
@@ -46,7 +47,10 @@ $(BIN)nxlandmine: landmine.o $(NXLIB)
 $(BIN)nxdemo: nxdemo.o $(NXLIB)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-$(BIN)npanel: npanel.o $(NXLIB)
+$(BIN)nxpanel: npanel.o $(NXLIB)
+	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+$(BIN)nxlaunch: launcher.o $(NXLIB)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 clean:

--- a/src/demos/nanox/launcher.c
+++ b/src/demos/nanox/launcher.c
@@ -495,7 +495,7 @@ void activate_screensaver(lstate *state)
 
 void deactivate_screensaver(lstate *state)
 {
-	if(sspid >= 0) kill(sspid, SIGINT);
+	if(sspid != -1) kill(sspid, SIGINT);
 }
 
 void handle_screensaver_event(lstate *state)

--- a/src/drivers/vgaplan4_cga.c
+++ b/src/drivers/vgaplan4_cga.c
@@ -57,10 +57,10 @@ cga_drawpixel(PSD psd, MWCOORD x,  MWCOORD y, MWPIXELVAL c)
 	/*if (y < psd->yres) {*/
 		dst = screenbase_table[y&1] + x / 8 + y / 2 * BYTESPERLINE;
 		if(gr_mode == MWROP_XOR) {
-			if (c) PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x&7]));
+			if ((unsigned int)c) PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x&7]));
 		} else {
-			if (c) ORBYTE_FP (dst,mask[x&7]);
-			else  ANDBYTE_FP (dst,~mask[x&7]);
+			if ((unsigned int)c) ORBYTE_FP (dst,mask[x&7]);
+			else				ANDBYTE_FP (dst,~mask[x&7]);
 		}
 	/*}*/
 	DRAWOFF;
@@ -106,15 +106,15 @@ cga_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y,
 			dst = screenbase_table[y&1] + x1 / 8 + y / 2 * BYTESPERLINE;
 			if (x1 / 8 == x2 / 8) {
 				while (x1 <= x2) {
-					if (c) ORBYTE_FP (dst,mask[x1&7]);
-					else  ANDBYTE_FP (dst,~mask[x1&7]);
+					if ((unsigned int)c) ORBYTE_FP (dst,mask[x1&7]);
+					else				ANDBYTE_FP (dst,~mask[x1&7]);
 					x1++;
 				}
 			} else {
 
 				while (x1 % 8) {
-					if (c) ORBYTE_FP (dst,mask[x1&7]);
-					else  ANDBYTE_FP (dst,~mask[x1&7]);
+					if ((unsigned int)c) ORBYTE_FP (dst,mask[x1&7]);
+					else				ANDBYTE_FP (dst,~mask[x1&7]);
 					x1++;
 				}
 				if (x1_ini % 8)
@@ -122,14 +122,14 @@ cga_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y,
 
 				last = screenbase_table[y&1] + x2 / 8 + y / 2 * BYTESPERLINE;
 				while (dst < last) {
-					if (c) PUTBYTE_FP (dst++, 255);
-					else   PUTBYTE_FP (dst++, 0);
+					if ((unsigned int)c) PUTBYTE_FP (dst++, 255);
+					else				 PUTBYTE_FP (dst++, 0);
 				}
 
 				x1 = ((x2 >> 3) << 3);
 				while (x1 <= x2) {
-					if (c) ORBYTE_FP (dst,mask[x1&7]);
-					else  ANDBYTE_FP (dst,~mask[x1&7]);
+					if ((unsigned int)c) ORBYTE_FP (dst,mask[x1&7]);
+					else				ANDBYTE_FP (dst,~mask[x1&7]);
 					x1++;
 				}
 			}
@@ -138,12 +138,12 @@ cga_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y,
 			dst = screenbase_table[y&1] + x1 / 8 + y / 2 * BYTESPERLINE;
 			if (x1 / 8 == x2 / 8) {
 				while(x1 <= x2) {
-					if (c) PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
+					if ((unsigned int)c) PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
 					x1++;
 				}
 			} else {
 				while (x1 % 8) {
-					if (c) PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
+					if ((unsigned int)c) PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
 					x1++;
 				}
 				if (x1_ini % 8)
@@ -151,21 +151,21 @@ cga_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y,
 
 				last = screenbase_table[y&1] + x2 / 8 + y / 2 * BYTESPERLINE;
 				while (dst < last) {
-					if (c) PUTBYTE_FP(dst,~GETBYTE_FP(dst));
+					if ((unsigned int)c) PUTBYTE_FP(dst,~GETBYTE_FP(dst));
 					dst++;
 				}
 
 				x1 = ((x2 >> 3) << 3);
 				while (x1 <= x2) {
-					if (c) PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
+					if ((unsigned int)c) PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
 					x1++;
 				}
 			}
 		} else {
 			/* slower method, draw pixel by pixel*/
 			while(x1 <= x2) {
-				if (c) ORBYTE_FP (screenbase_table[y&1] + x1 / 8 + y / 2 * BYTESPERLINE,mask[x1&7]);
-				else  ANDBYTE_FP (screenbase_table[y&1] + x1 / 8 + y / 2 * BYTESPERLINE,~mask[x1&7]);
+				if ((unsigned int)c) ORBYTE_FP (screenbase_table[y&1] + x1 / 8 + y / 2 * BYTESPERLINE,mask[x1&7]);
+				else			 	ANDBYTE_FP (screenbase_table[y&1] + x1 / 8 + y / 2 * BYTESPERLINE,~mask[x1&7]);
 				x1++;
 			}
 		}
@@ -190,14 +190,14 @@ cga_drawvertline(PSD psd, MWCOORD x,  MWCOORD y1,  MWCOORD y2, MWPIXELVAL c)
 	if(gr_mode == MWROP_XOR) {
 		while (y <= y2 /*&& y < psd->yres*/) {
 			dst = screenbase_table[y&1] + x / 8 + y / 2 * BYTESPERLINE;
-			if (c) PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x&7]));
+			if ((unsigned int)c) PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x&7]));
 			y++;
 		}
 	} else {
 		while (y <= y2 /*&& y < psd->yres*/) {
 			dst = screenbase_table[y&1] + x / 8 + y / 2 * BYTESPERLINE;
-			if (c) ORBYTE_FP (dst,mask[x&7]);
-			else  ANDBYTE_FP (dst,~mask[x&7]);
+			if ((unsigned int)c) ORBYTE_FP (dst,mask[x&7]);
+			else			 	ANDBYTE_FP (dst,~mask[x&7]);
 			y++;
 		}
 	}

--- a/src/drivers/vgaplan4_mem.c
+++ b/src/drivers/vgaplan4_mem.c
@@ -57,9 +57,9 @@ mempl4_drawpixel(PSD psd, MWCOORD x, MWCOORD y, MWPIXELVAL c)
 
 	addr += (x>>1) + y * psd->pitch;
 	if(gr_mode == MWROP_XOR)
-		*addr ^= c << ((1-(x&1))<<2);
+		*addr ^= (unsigned int)c << ((1-(x&1))<<2);
 	else
-		*addr = (*addr & notmask[x&1]) | (c << ((1-(x&1))<<2));
+		*addr = (*addr & notmask[x&1]) | ((unsigned int)c << ((1-(x&1))<<2));
 }
 
 /* Read pixel at x, y*/
@@ -91,13 +91,13 @@ mempl4_drawhorzline(PSD psd, MWCOORD x1, MWCOORD x2, MWCOORD y, MWPIXELVAL c)
 	addr += (x1>>1) + y * psd->pitch;
 	if(gr_mode == MWROP_XOR) {
 		while(x1 <= x2) {
-			*addr ^= c << ((1-(x1&1))<<2);
+			*addr ^= (unsigned int)c << ((1-(x1&1))<<2);
 			if((++x1 & 1) == 0)
 				++addr;
 		}
 	} else {
 		while(x1 <= x2) {
-			*addr = (*addr & notmask[x1&1]) | (c << ((1-(x1&1))<<2));
+			*addr = (*addr & notmask[x1&1]) | ((unsigned int)c << ((1-(x1&1))<<2));
 			if((++x1 & 1) == 0)
 				++addr;
 		}
@@ -121,12 +121,12 @@ mempl4_drawvertline(PSD psd, MWCOORD x, MWCOORD y1, MWCOORD y2, MWPIXELVAL c)
 	addr += (x>>1) + y1 * pitch;
 	if(gr_mode == MWROP_XOR)
 		while(y1++ <= y2) {
-			*addr ^= c << ((1-(x&1))<<2);
+			*addr ^= (unsigned int)c << ((1-(x&1))<<2);
 			addr += pitch;
 		}
 	else
 		while(y1++ <= y2) {
-			*addr = (*addr & notmask[x&1]) | (c << ((1-(x&1))<<2));
+			*addr = (*addr & notmask[x&1]) | ((unsigned int)c << ((1-(x&1))<<2));
 			addr += pitch;
 		}
 }
@@ -327,8 +327,7 @@ vga_to_mempl4_blit(PSD dstpsd, MWCOORD dstx, MWCOORD dsty, MWCOORD w, MWCOORD h,
 			for(plane = 0; plane < 4; ++plane) {
 				set_read_plane(plane);
 				if(GETBYTE_FP(s) & mask[sx & 7])
-					color |= 1 <<
-						(plane + ((dx & 1) ? 0 : 4));
+					color |= 1 << (plane + ((dx & 1) ? 0 : 4));
 			}
 			if((++sx & 7) == 0) ++s;
 			if((++dx & 1) == 0) {

--- a/src/drivers/vgaplan4_pc98.c
+++ b/src/drivers/vgaplan4_pc98.c
@@ -62,14 +62,14 @@ pc98_drawpixel(PSD psd, MWCOORD x,  MWCOORD y, MWPIXELVAL c)
 	if(gr_mode == MWROP_XOR) {
 		for(plane=0; plane<4; ++plane) {
 			dst = screenbase_table[plane] + x / 8 + y * BYTESPERLINE;
-			if  (c & (1 << plane)) {
+			if  ((unsigned int)c & (1 << plane)) {
 				PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x&7]));
 			}
 		}
 	} else {
 		for(plane=0; plane<4; ++plane) {
 			dst = screenbase_table[plane] + x / 8 + y * BYTESPERLINE;
-			if  (c & (1 << plane)) {
+			if  ((unsigned int)c & (1 << plane)) {
 				ORBYTE_FP (dst,mask[x&7]);
 			}
 			else {
@@ -86,7 +86,7 @@ pc98_readpixel(PSD psd, MWCOORD x, MWCOORD y)
 {
 	FARADDR		src;
 	int		    plane;
-	MWPIXELVAL	c = 0;
+	unsigned int c = 0;
 
 	assert (x >= 0 && x < psd->xres);
 	assert (y >= 0 && y < psd->yres);
@@ -123,10 +123,9 @@ pc98_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y, MWPIXELVAL c)
 			dst = screenbase_table[plane] + x1 / 8 + y * BYTESPERLINE;
 			if (x1 / 8 == x2 / 8) {
 				while(x1 <= x2) {
-					if  (c & (1 << plane)) {
+					if  ((unsigned int)c & (1 << plane)) {
 						ORBYTE_FP (dst,mask[x1&7]);
-					}
-					else {
+					} else {
 						ANDBYTE_FP (dst,~mask[x1&7]);
 					}
 					x1++;
@@ -134,10 +133,9 @@ pc98_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y, MWPIXELVAL c)
 			} else {
 
 				while (x1 % 8) {
-					if  (c & (1 << plane)) {
+					if  ((unsigned int)c & (1 << plane)) {
 						ORBYTE_FP (dst,mask[x1&7]);
-					}
-					else {
+					} else {
 						ANDBYTE_FP (dst,~mask[x1&7]);
 					}
 					x1++;
@@ -147,10 +145,9 @@ pc98_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y, MWPIXELVAL c)
 
 				last = screenbase_table[plane] + x2 / 8 + y * BYTESPERLINE;
 				while (dst < last) {
-					if  (c & (1 << plane)) {
+					if  ((unsigned int)c & (1 << plane)) {
 						PUTBYTE_FP(dst, 255);
-					}
-					else {
+					} else {
 						PUTBYTE_FP(dst, 0);
 					}
 					dst++;
@@ -158,10 +155,9 @@ pc98_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y, MWPIXELVAL c)
 
 				x1 = ((x2 >> 3) << 3);
 				while (x1 <= x2) {
-					if  (c & (1 << plane)) {
+					if  ((unsigned int)c & (1 << plane)) {
 						ORBYTE_FP (dst,mask[x1&7]);
-					}
-					else {
+					} else {
 						ANDBYTE_FP (dst,~mask[x1&7]);
 					}
 					x1++;
@@ -174,7 +170,7 @@ pc98_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y, MWPIXELVAL c)
 			dst = screenbase_table[plane] + x1 / 8 + y * BYTESPERLINE;
 			if (x1 / 8 == x2 / 8) {
 				while(x1 <= x2) {
-					if  (c & (1 << plane)) {
+					if  ((unsigned int)c & (1 << plane)) {
 						PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
 					}
 					x1++;
@@ -182,7 +178,7 @@ pc98_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y, MWPIXELVAL c)
 			} else {
 
 				while (x1 % 8) {
-					if  (c & (1 << plane)) {
+					if  ((unsigned int)c & (1 << plane)) {
 						PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
 					}
 					x1++;
@@ -192,7 +188,7 @@ pc98_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y, MWPIXELVAL c)
 
 				last = screenbase_table[plane] + x2 / 8 + y * BYTESPERLINE;
 				while (dst < last) {
-					if  (c & (1 << plane)) {
+					if  ((unsigned int)c & (1 << plane)) {
 						PUTBYTE_FP(dst,~GETBYTE_FP(dst));
 						dst++;
 					}
@@ -200,7 +196,7 @@ pc98_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y, MWPIXELVAL c)
 
 				x1 = ((x2 >> 3) << 3);
 				while (x1 <= x2) {
-					if  (c & (1 << plane)) {
+					if  ((unsigned int)c & (1 << plane)) {
 						PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
 					}
 					x1++;
@@ -211,10 +207,9 @@ pc98_drawhorzline(PSD psd,  MWCOORD x1,  MWCOORD x2,  MWCOORD y, MWPIXELVAL c)
 		/* slower method, draw pixel by pixel*/
 		while(x1 <= x2) {
 			for(plane=0; plane<4; ++plane) {
-				if  (c & (1 << plane)) {
+				if  ((unsigned int)c & (1 << plane)) {
 					ORBYTE_FP (screenbase_table[plane] + x1 / 8 + y * BYTESPERLINE,mask[x1&7]);
-				}
-				else {
+				} else {
 					ANDBYTE_FP (screenbase_table[plane] + x1 / 8 + y * BYTESPERLINE,~mask[x1&7]);
 				}
 			}
@@ -243,7 +238,7 @@ pc98_drawvertline(PSD psd, MWCOORD x,  MWCOORD y1,  MWCOORD y2, MWPIXELVAL c)
 			dst = screenbase_table[plane] + x / 8 + y1 * BYTESPERLINE;
 			last = screenbase_table[plane] + x / 8 + y2 * BYTESPERLINE;
 			while (dst <= last) {
-				if  (c & (1 << plane)) {
+				if  ((unsigned int)c & (1 << plane)) {
 					PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x&7]));
 				}
 				dst += BYTESPERLINE;
@@ -254,10 +249,9 @@ pc98_drawvertline(PSD psd, MWCOORD x,  MWCOORD y1,  MWCOORD y2, MWPIXELVAL c)
 			dst = screenbase_table[plane] + x / 8 + y1 * BYTESPERLINE;
 			last = screenbase_table[plane] + x / 8 + y2 * BYTESPERLINE;
 			while (dst <= last) {
-				if  (c & (1 << plane)) {
+				if  ((unsigned int)c & (1 << plane)) {
 					ORBYTE_FP (dst,mask[x&7]);
-				}
-				else {
+				} else {
 					ANDBYTE_FP (dst,~mask[x&7]);
 				}
 				dst += BYTESPERLINE;

--- a/src/drivers/vgaplan4_vga.c
+++ b/src/drivers/vgaplan4_vga.c
@@ -115,7 +115,7 @@ vga_drawhorzline(PSD psd, MWCOORD x1, MWCOORD x2, MWCOORD y, MWPIXELVAL c)
 	assert (c < psd->ncolors);
 
 	DRAWON;
-	set_color (c);
+	set_color ((int)c);
 	set_op(mode_table[gr_mode]);
 	/*
 	* The following fast drawhline code is buggy for XOR drawing,

--- a/src/engine/devopen.c
+++ b/src/engine/devopen.c
@@ -16,6 +16,8 @@
 
 #if MSDOS | ELKS
 #define NOSTDPAL8
+#define NOSTDPAL4
+#define NOSTDPAL2
 #endif
 
 /*

--- a/src/engine/devopen.c
+++ b/src/engine/devopen.c
@@ -16,7 +16,6 @@
 
 #if MSDOS | ELKS
 #define NOSTDPAL8
-#define NOSTDPAL4
 #define NOSTDPAL2
 #endif
 

--- a/src/include/nanowm.h
+++ b/src/include/nanowm.h
@@ -27,12 +27,15 @@
 #if NUKLEARUI						/* draw window frames/colors to match Nuklear style*/
 #if ELKS
 #define SCHEME_NUK16 1              /* 16 color nuklear! */
+#define CYCAPTION	25				/* height of caption*/
+#define CYTEXTBASE  8               /* baseline for font */
 #else
 #define SCHEME_NUKLEAR 1			/* nuklear color scheme*/
+#define CYCAPTION	29				/* height of caption*/
+#define CYTEXTBASE  11              /* baseline for font */
 #endif
 #define CXBORDER	1				/* 3d border width*/
 #define CYBORDER	1				/* 3d border height*/
-#define CYCAPTION	29				/* height of caption*/
 #define CXCLOSEBOX	20				/* width of closebox*/
 #define CYCLOSEBOX	20				/* height of closebox*/
 #define CXFRAME		(CXBORDER*2)	/* width of frame*/

--- a/src/nanox/nxdraw.c
+++ b/src/nanox/nxdraw.c
@@ -263,19 +263,19 @@ nxPaintNCArea(GR_DRAW_ID id, int w, int h, char *title, GR_BOOL active, GR_WM_PR
 		goto out;
 
 	/* fill caption*/
-	GrSetGCForeground(gc, 
-		GrGetSysColor(active? GR_COLOR_ACTIVECAPTION: GR_COLOR_INACTIVECAPTION));
+	GrSetGCForeground(gc, GrGetSysColor(active?
+		GR_COLOR_ACTIVECAPTION: GR_COLOR_INACTIVECAPTION));
 	GrFillRect(id, gc, x, y, w, CYCAPTION);
 
 	/* draw caption text*/
 	if (title) {
-		GrSetGCForeground(gc,
-			GrGetSysColor(active? GR_COLOR_ACTIVECAPTIONTEXT: GR_COLOR_INACTIVECAPTIONTEXT));
+		GrSetGCForeground(gc, GrGetSysColor(active?
+			GR_COLOR_ACTIVECAPTIONTEXT: GR_COLOR_INACTIVECAPTIONTEXT));
 		GrSetGCUseBackground(gc, GR_FALSE);
 #if NUKLEARUI
 		/* X = 2 times padding (4)*/
 		/* Y = 2 times padding (4) + font ascent+descent (11)*/
-		GrText(id, gc, x+2*4, y+2*4+11, title, -1, GR_TFASCII|GR_TFBASELINE);
+		GrText(id, gc, x+2*4, y+2*4+CYTEXTBASE, title, -1, GR_TFASCII|GR_TFBASELINE);
 #else
 		GrText(id, gc, x+4, y-1, title, -1, GR_TFASCII|GR_TFTOP);
 #endif
@@ -290,12 +290,13 @@ nxPaintNCArea(GR_DRAW_ID id, int w, int h, char *title, GR_BOOL active, GR_WM_PR
 
 	if (props & GR_WM_PROPS_CLOSEBOX) {
 #if NUKLEARUI
-		GrSetGCForeground(gc,
-			GrGetSysColor(active? GR_COLOR_ACTIVECAPTIONTEXT: GR_COLOR_INACTIVECAPTIONTEXT));
+		GrSetGCForeground(gc, GrGetSysColor(active?
+				GR_COLOR_ACTIVECAPTIONTEXT: GR_COLOR_INACTIVECAPTIONTEXT));
 		GrSetGCUseBackground(gc, GR_FALSE);
 		/* X = width - 3 - "x" width (5) - 2 times padding (4)*/
 		/* Y = 2 times padding (4) + font ascent+descent (11)*/
-		GrText(id, gc, x+w-3-5-8, y-CYCAPTION+8+11, "x", 1, GR_TFASCII|GR_TFBASELINE);
+		GrText(id, gc, x+w-3-5-8, y-CYCAPTION+8+CYTEXTBASE, "x", 1,
+			GR_TFASCII|GR_TFBASELINE);
 #else
 		GR_RECT		r;
 		/* draw close box*/


### PR DESCRIPTION
A hardware color is passed to the screen driver as MWPIXELVAL, which is 32-bits, so long arithmetic was being used in all the VGA screen drivers for manipulating color, resulting in lots of slowdown. They're fast now, but a better solution would be using MWPIXELVALHW for driver color parameters.

Reduces title bar by 4 pixels for ELKS which displays better on smaller 640x480 screens.

`npanel` was renamed `nxpanel` so startup now is:
```
./nano-X & ./nxpanel
```

Here's a bootable 2880k image and screenshot:
[fd2880.img.zip](https://github.com/user-attachments/files/18722935/fd2880.img.zip)

<img width="752" alt="NX smaller caption" src="https://github.com/user-attachments/assets/d5060425-87e6-4906-8685-b37aeaeb0a2b" />

