### PR TITLE
Port nxterm to ELKS and lots of bug fixes

### DIFF
--- a/src/Makefile.elks
+++ b/src/Makefile.elks
@@ -14,8 +14,9 @@ CONFIG_ARCH_PC98=n
 
 # remove any -mregparmcall as ASM files need cdecl calling convention
 CFLAGS := $(filter-out -mregparmcall, $(CFLAGS))
-CFLAGS += -DELKS=1 -DUNIX=1 -DNANOWM=1 -DNDEBUG=1
+CFLAGS += -DELKS=1 -DUNIX=1 -DNDEBUG=1
 CFLAGS += -DMWPIXEL_FORMAT=MWPF_PALETTE -DSCREEN_PIXTYPE=MWPF_PALETTE
+CFLAGS += -DUSE_SMALL_CURSOR=1
 CFLAGS += -Iinclude -Ielksdrivers -I$(TOPDIR)/cross/lib/gcc/ia16-elf/6.3.0/include
 CFLAGS += -Wno-unused-variable -Wno-unused-but-set-variable
 CFLAGS += -Wno-missing-field-initializers
@@ -23,6 +24,7 @@ AR = ia16-elf-ar
 
 # screen, mouse and kbd drivers
 ifeq ($(CONFIG_ARCH_PC98), y)
+CFLAGS += -DCONFIG_ARCH_PC98=1
 DRIVERS += drivers/scr_pc98.o drivers/vgaplan4_pc98.o drivers/vgaplan4_mem.o
 DRIVERS += drivers/mou_pc98.o drivers/kbd_tty.o
 #DRIVERS += drivers/ramfont.o

--- a/src/config
+++ b/src/config
@@ -44,10 +44,10 @@ X11HDRLOCATION           = $(MW_DIR_SRC)/nx11/X11-local
 # Libraries to build: microwin, nano-X, nxlib, engine
 #
 ####################################################################
-MICROWIN                 = Y
+MICROWIN                 = N
 NANOX                    = Y
 NUKLEARUI                = Y
-NX11                     = Y
+NX11                     = N
 ENGINE                   = N
 TINYWIDGETS              = N
 
@@ -57,7 +57,7 @@ TINYWIDGETS              = N
 #
 ####################################################################
 FBEMULATOR               = N
-MICROWINDEMO             = Y
+MICROWINDEMO             = N
 MICROWINMULTIAPP         = N
 NANOXDEMO                = Y
 HAVE_VNCSERVER_SUPPORT   = N

--- a/src/demos/nanox/Makefile
+++ b/src/demos/nanox/Makefile
@@ -107,7 +107,7 @@ ifneq ($(ARCH),CYGWIN)
   ifneq ($(ARCH),RTEMS)
     ifneq ($(ARCH),ANDROID)
       ifneq ($(ARCH),AQUILA)
-        #TARGETS += $(MW_DIR_BIN)/nxterm
+        TARGETS += $(MW_DIR_BIN)/nxterm
       endif
     endif
   endif

--- a/src/demos/nanox/Makefile.elks
+++ b/src/demos/nanox/Makefile.elks
@@ -15,11 +15,12 @@ NXLIB = ../../lib/libnano-X.a
 ###############################################################################
 
 PROGS   = \
-    $(BIN)nxclock   \
-    $(BIN)nxtetris  \
-    $(BIN)nxworld   \
+    $(BIN)nxclock    \
+    $(BIN)nxtetris   \
+    $(BIN)nxworld    \
     $(BIN)nxpanel    \
-    $(BIN)nxlandmine\
+    $(BIN)nxlandmine \
+    $(BIN)nxterm     \
 
 notyet = \
     $(BIN)nxterm    \

--- a/src/demos/nanox/npanel.c
+++ b/src/demos/nanox/npanel.c
@@ -339,7 +339,7 @@ do_buttondown(GR_EVENT_BUTTON *ep)
 	static int app_no;
 
 	if (ep->wid == w1) {
-        int y = MWMAX(ep->y - 2, 0);        /* FIXME fudge */
+		int y = MWMAX(ep->y - 2, 0);        /* FIXME fudge */
 		app_no = y / fheight;
 		if (app_no >= num_apps) {
 			app_no = num_apps - 1;

--- a/src/demos/nanox/npanel.c
+++ b/src/demos/nanox/npanel.c
@@ -9,7 +9,8 @@
    Unfortunately since outline moves are not supported yet, the only
    alternative is "invisible" moving.
 */ 
-#define WINDOW_MANAGER      0
+#define WINDOW_MANAGER      0   /* = 1 for window manager code */
+#define ROOT_WIN_RECOLOR    0   /* =1 to recolor desktop to gray */
 #define SHOW_WINDOW_MOTION  1
 
 /*
@@ -40,11 +41,13 @@
 
 static	GR_WINDOW_ID	w1;		/* id for launcher window */
 static	GR_GC_ID	gc;		/* graphics context for rectangle */
-static	GR_GC_ID	bgc;		/* graphics context for rectangle */
 static	GR_SCREEN_INFO	si;		/* information about screen */
 static	int		fwidth, fheight;
 static	int		fbase;
 static	int		num_apps = 0;
+#if ROOT_WIN_RECOLOR
+static	GR_GC_ID	bgc;		/* graphics context for rectangle */
+#endif
 
 static void do_exposure(GR_EVENT_EXPOSURE *ep);
 static void do_buttondown(GR_EVENT_BUTTON *ep);
@@ -119,13 +122,12 @@ main(int argc,char **argv)
 	GrGetScreenInfo(&si);
 
 	signal(SIGCHLD, &reaper);
-
-	gc = GrNewGC();
+#if ROOT_WIN_RECOLOR
 	bgc = GrNewGC();
-
 	GrSetGCForeground(bgc, GRAY);
+#endif
+	gc = GrNewGC();
 	GrSetGCFont(gc, GrCreateFontEx(GR_FONT_SYSTEM_FIXED, 0, 0, NULL));
-
 	GrGetGCTextSize(gc, "A", 1, GR_TFASCII, &fwidth, &fheight, &fbase);
 	width = fwidth * 8 + 4;
 	height = fheight * num_apps + 4;
@@ -159,8 +161,9 @@ main(int argc,char **argv)
 	GrSetCursor(w1, 7, 7, 3, 3, WHITE, BLACK, bitmap1fg, bitmap1bg);
 #endif
 
+#if ROOT_WIN_RECOLOR
 	GrFillRect(GR_ROOT_WINDOW_ID, bgc, 0, 0, si.cols, si.rows);
-
+#endif
 	GrSetGCForeground(gc, BLACK);
 	GrSetGCBackground(gc, WHITE);
 
@@ -318,10 +321,12 @@ do_exposure(GR_EVENT_EXPOSURE *ep)
 			GrText(w1, gc, 2, 2 + fheight * (app_no + 1),
 				act->app_id, -1, GR_TFBOTTOM);
 		}
-	} else if (ep->wid == GR_ROOT_WINDOW_ID) {
-		GrFillRect(GR_ROOT_WINDOW_ID, bgc, ep->x, ep->y,
-				ep->width, ep->height);
 	}
+#if ROOT_WIN_RECOLOR
+	else if (ep->wid == GR_ROOT_WINDOW_ID) {
+		GrFillRect(GR_ROOT_WINDOW_ID, bgc, ep->x, ep->y, ep->width, ep->height);
+	}
+#endif
 }
 
 extern char ** environ;
@@ -334,7 +339,8 @@ do_buttondown(GR_EVENT_BUTTON *ep)
 	static int app_no;
 
 	if (ep->wid == w1) {
-		app_no = ep->y / fheight;
+        int y = MWMAX(ep->y - 2, 0);        /* FIXME fudge */
+		app_no = y / fheight;
 		if (app_no >= num_apps) {
 			app_no = num_apps - 1;
 		}

--- a/src/demos/nanox/nxclock.c
+++ b/src/demos/nanox/nxclock.c
@@ -78,6 +78,39 @@ main(int ac, char **av)
 	GrSetGCForeground(gc2, GrGetSysColor(GR_COLOR_WINDOWTEXT));
 	GrSetGCBackground(gc2, GrGetSysColor(GR_COLOR_WINDOW));
 
+#if 0
+	bitmap1fg[0] = 0; //MASK(X,X,X,X,X,X,X);
+	bitmap1fg[1] = 0; //MASK(X,X,X,X,X,X,X);
+	bitmap1fg[2] = 0; //MASK(X,X,X,X,X,X,X);
+	bitmap1fg[3] = 0; //MASK(X,X,X,X,X,X,X);
+	bitmap1fg[4] = 0; //MASK(X,X,X,X,X,X,X);
+	bitmap1fg[5] = 0; //MASK(X,X,X,X,X,X,X);
+	bitmap1fg[6] = 0; //MASK(X,X,X,X,X,X,X);
+
+	bitmap1bg[0] = MASK(X,X,X,X,X,_,_);
+	bitmap1bg[1] = MASK(X,X,X,X,_,_,_);
+	bitmap1bg[2] = MASK(X,X,X,_,_,_,_);
+	bitmap1bg[3] = MASK(X,X,X,X,_,_,_);
+	bitmap1bg[4] = MASK(X,_,_,X,X,_,_);
+	bitmap1bg[5] = MASK(_,_,_,_,X,X,_);
+	bitmap1bg[6] = MASK(_,_,_,_,_,X,X);
+#elif 0
+	bitmap1fg[0] = MASK(_,_,_,_,X,X,X);
+	bitmap1fg[1] = MASK(_,_,X,X,X,X,X);
+	bitmap1fg[2] = MASK(_,X,_,X,X,X,X);
+	bitmap1fg[3] = MASK(_,X,X,_,X,X,X);
+	bitmap1fg[4] = MASK(X,X,X,X,_,X,X);
+	bitmap1fg[5] = MASK(X,X,X,X,X,X,X);
+	bitmap1fg[6] = MASK(X,X,X,X,X,X,X);
+
+	bitmap1bg[0] = MASK(X,X,X,X,_,_,_);
+	bitmap1bg[1] = MASK(X,X,_,_,_,_,_);
+	bitmap1bg[2] = MASK(X,_,X,_,_,_,_);
+	bitmap1bg[3] = MASK(_,_,_,X,_,_,_);
+	bitmap1bg[4] = MASK(_,_,_,_,X,_,_);
+	bitmap1bg[5] = MASK(_,_,_,_,_,_,_);
+	bitmap1bg[6] = MASK(_,_,_,_,_,_,_);
+#else
 	bitmap1fg[0] = MASK(_,X,X,X,X,X,_);
 	bitmap1fg[1] = MASK(X,_,X,X,X,_,X);
 	bitmap1fg[2] = MASK(X,X,_,X,_,X,X);
@@ -93,6 +126,7 @@ main(int ac, char **av)
 	bitmap1bg[4] = MASK(_,_,X,_,X,_,_);
 	bitmap1bg[5] = MASK(_,X,_,_,_,X,_);
 	bitmap1bg[6] = MASK(X,_,_,_,_,_,X);
+#endif
 
 	GR_CURSOR_ID cid = GrNewCursor(7, 7, 3, 3, WHITE, BLACK, bitmap1fg, bitmap1bg);
 	GrSetWindowCursor(w1, cid);

--- a/src/demos/nanox/nxterm.h
+++ b/src/demos/nanox/nxterm.h
@@ -73,8 +73,4 @@ k1=\\EP:k2=\\EQ:k3=\\ER:k4=\\ES:k5=\\ET:k6=\\EU:k7=\\EV:k8=\\EW:k9=\\EX:\
 s0=\\Ey:s1=\\Ep:s2=\\Eq:s3=\\Er:s4=\\Es:s5=\\Et:s6=\\Eu:s7=\\Ev:s8=\\Ew:\
 s9=\\Ex:";
 
-#else
-
-#error no termtype/termcap string defined for nxterm.h
-
 #endif

--- a/src/drivers/kbd_tty.c
+++ b/src/drivers/kbd_tty.c
@@ -157,8 +157,8 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 	
 	mwkey = buf[0];
 #if ELKS
-	if(mwkey == '\033')
-		return -2;	/* special case ESC*/
+	if(mwkey == 01)         /* exit on ^A */
+		return KBD_QUIT;
 #elif __fiwix__
     if (mwkey == 03)
         mwkey = MWKEY_QUIT;

--- a/src/engine/devblit.c
+++ b/src/engine/devblit.c
@@ -17,6 +17,7 @@
 #include <assert.h>
 #include "device.h"
 #include "convblit.h"
+#define DEBUG_BLIT  0
 
 /* find a conversion blit based on data format and blit op*/
 /* used by GdBitmap, GdArea and GdDrawImage*/
@@ -234,6 +235,7 @@ GdBlit(PSD dstpsd, MWCOORD dstx, MWCOORD dsty, MWCOORD width, MWCOORD height,
 	GdConvBlitInternal(dstpsd, &parms, frameblit);
 }
 
+#if MW_FEATURE_AREAS
 /**
  * A proper stretch blit.  Supports flipping the image.
  * Parameters are co-ordinates of two points in the source, and
@@ -564,6 +566,7 @@ GdStretchBlit(PSD dstpsd, MWCOORD dx1, MWCOORD dy1, MWCOORD dx2,
 	if (srcpsd != dstpsd)
 		GdFixCursor(srcpsd);
 }
+#endif
 
 /* call conversion blit with clipping and cursor fix*/
 void

--- a/src/include/mwconfig.h
+++ b/src/include/mwconfig.h
@@ -31,6 +31,7 @@
 #endif
 
 #if ELKS
+#define NANOWM			1		/* =1 for builtin nano-X window manager*/
 #define USE_ALLOCA		0		/* =1 if alloca() is available*/
 #define HAVE_MMAP       0       /* =1 has mmap system call*/
 #define HAVE_SIGNAL		0		/* =1 has signal system call*/

--- a/src/nanox/nxdraw.c
+++ b/src/nanox/nxdraw.c
@@ -57,8 +57,8 @@ const GR_COLOR nxSysColors[MAXSYSCOLORS] = {
 #if SCHEME_NUK16
 const GR_COLOR nxSysColors[MAXSYSCOLORS] = {
 	/* desktop background*/
-	//GR_RGB(  0,   0,   0),  /* GR_COLOR_DESKTOP             */
-	GR_RGB(  0, 127, 127),  /* GR_COLOR_DESKTOP             */
+	//GR_RGB(  0, 127, 127),  /* GR_COLOR_DESKTOP             */
+	GR_RGB(128, 128, 128),  /* GR_COLOR_DESKTOP             */
 
 	/* caption colors*/
 	GR_RGB(127, 127, 127),	/* GR_COLOR_ACTIVECAPTION       */

--- a/src/nanox/srvmain.c
+++ b/src/nanox/srvmain.c
@@ -504,16 +504,15 @@ again:
 	if(e > 0)			/* input ready*/
 	{
 		/* service mouse file descriptor*/
-		if(mouse_fd >= 0 && FD_ISSET(mouse_fd, &rfds)) {
-			while(GsCheckMouseEvent()) {
+		if(mouse_fd >= 0 && FD_ISSET(mouse_fd, &rfds))
+			while(GsCheckMouseEvent())
 				continue;
-			}
-		}
+
 		/* service keyboard file descriptor*/
-		if(keyb_fd >= 0 && FD_ISSET(keyb_fd, &rfds)) {
+		if(keyb_fd >= 0 && FD_ISSET(keyb_fd, &rfds))
 			while(GsCheckKeyboardEvent())
 				continue;
-		}
+
 #if NONETWORK
 		/* check for input on registered file descriptors */
 		for (fd = 0; fd < regfdmax; fd++)
@@ -545,7 +544,6 @@ again:
 			curclient_next = curclient->next;
 			if(FD_ISSET(curclient->id, &rfds))
 				GsHandleClient(curclient->id);
-
 			curclient = curclient_next;
 		}
 #endif /* NONETWORK */

--- a/src/nanox/srvmain.c
+++ b/src/nanox/srvmain.c
@@ -505,16 +505,14 @@ again:
 	{
 		/* service mouse file descriptor*/
 		if(mouse_fd >= 0 && FD_ISSET(mouse_fd, &rfds)) {
-            GsCheckMouseEvent();
-			//while(GsCheckMouseEvent()) {
-				//continue;
-			//}
+			while(GsCheckMouseEvent()) {
+				continue;
+			}
 		}
 		/* service keyboard file descriptor*/
 		if(keyb_fd >= 0 && FD_ISSET(keyb_fd, &rfds)) {
-			while(GsCheckKeyboardEvent()) {
+			while(GsCheckKeyboardEvent())
 				continue;
-			}
 		}
 #if NONETWORK
 		/* check for input on registered file descriptors */

--- a/src/nanox/srvutil.c
+++ b/src/nanox/srvutil.c
@@ -382,6 +382,7 @@ GsDestroyPixmap(GR_PIXMAP *pp)
 	free(pp);
 }
 
+#if MW_FEATURE_AREAS
 /*
  * Draw a window's background pixmap.
  *
@@ -581,6 +582,7 @@ GsTileBackgroundPixmap(GR_WINDOW *wp, GR_PIXMAP *pm, GR_COORD x, GR_COORD y,
 		}
 	}
 }
+#endif
 
 /* init buffered windows by allocating pixmap buffer and clearing background*/
 void
@@ -794,8 +796,10 @@ usleep(500000);
 				if (!(wp->bgpixmapflags & GR_BACKGROUND_TRANS))
 					GdFillRect(wp->psd, wp->x + x, wp->y + y, width, height);
 
+#if MW_FEATURE_AREAS
 		if (wp->bgpixmap)
 			GsDrawBackgroundPixmap(wp, wp->bgpixmap, x, y, width, height);
+#endif
 	}
 
 	/*


### PR DESCRIPTION
Nxterm is now available and running on ELKS! 

Creating this PR took quite some time because quite a few other issues were found, particularly in the VGA drivers, that took forever to solve. There remain a number of issues and desired enhancements to nxterm, but progress overall looks good for the Nano-X ELKS port, and this PR also fixes a number of problems seen operating on slow systems.

Most testing was done on QEMU by running the Nano-X panel program launcher after building and booting ELKS using:

Building Nano-X for ELKS
```
$ make clean
$ make -f Makefile.elks clean
$ make -f Makefile.elks
$ cd $TOPDIR
$ make
```
Running Nano-X within ELKS
```
login: root
# ./nano-X & ./npanel
```

Features added and bugs fixed for ELKS:
- Nxterm port. Lots of fixes for all platforms, including non-buggy up/down scrolling - enough to run ELKS vi. Still needs some ANSI reverse scrolling fixes.
- Exit Nano-X on ^A instead of ESC. This was required because vi uses ESC.
- Desktop color changed from CYAN to GRAY for more modern look on 16-color VGA.
- Add USE_SMALL_CURSOR for small 8x8, rather than 16x16 cursor. Lots of CPU time is spent just redrawing the cursor and having a cursor 1/4 the size makes quite a bit a difference.
- Nano-X event fixes: some window move starts were ignored, and sometimes mouse events weren't processed until next event occurred (e.g. end of window move not acknowledged properly and cursor not changing after window move).
- VGA blit routine bug after XOR used. Blit still improperly draws outside the application on scrolling. 
- VGA speedups on horizontal line draw and draw pixel.
- More size reduction of Nano-X client/server libraries for ELKS.
- Fixes issues brought up in https://github.com/ghaerr/microwindows/pull/95#issuecomment-2646575057 by @toncho11.

Known bugs:
- Window contents sometimes not refreshed when clicking on titlebar.
- Screen contents just outside the left or right side of nxterm is overwritten when scrolling due to VGA planes blit bug.

Needs enhancements:
- Nxterm is very slow scrolling on slow systems!!
- Nxterm doesn't redisplay contents after being obscured.
- Nano-X redisplays application background twice on startup (because of window manager caption drawn).
- Nxclock time display can look funny when app display becomes unobscured (because of XOR drawing mode).

For those without time to build ELKS, attached is a bootable 2880k floppy image with Nano-X ready to run as described above:
[fd2880.img.zip](https://github.com/user-attachments/files/18762202/fd2880.img.zip)

Here's a screenshot showing the (optional) small cursor used for ELKS (to the right of nxterm window):
<img width="752" alt="NX cursor" src="https://github.com/user-attachments/assets/e471c81c-0a72-4b05-bf3f-b5b85d86f39b" />
