### PR TITLE
Update ELKS paths in nxstart, partial fix for closebox

### DIFF
--- a/src/Makefile.elks
+++ b/src/Makefile.elks
@@ -82,7 +82,7 @@ lib/libnano-X.a: $(CLIENT)
 
 bin/nano-X: $(SERVER)
 	$(LD) $(LDFLAGS) -maout-heap=0x2000 -o $@ $^ $(LDLIBS)
-	cp $@ $(TOPDIR)/elkscmd/rootfs_template/root
+	cp $@ $(TOPDIR)/elkscmd/rootfs_template/bin
 
 nxdemos: lib/libnano-X.a
 	$(MAKE) -C demos/nanox -f Makefile.elks all

--- a/src/demos/nanox/Makefile.elks
+++ b/src/demos/nanox/Makefile.elks
@@ -26,7 +26,7 @@ notyet = \
     $(BIN)nxlaunch\
 
 all: $(PROGS)
-	cp -p $(PROGS) $(TOPDIR)/elkscmd/rootfs_template/root
+	cp -p $(PROGS) $(TOPDIR)/elkscmd/rootfs_template/bin
 
 $(BIN)nxclock: nxclock.o $(NXLIB)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)

--- a/src/demos/nanox/nxstart.c
+++ b/src/demos/nanox/nxstart.c
@@ -57,7 +57,7 @@ static void do_update(GR_EVENT_UPDATE *ep);
 static void do_mouse(GR_EVENT_MOUSE *ep);
 
 #if ELKS
-#define PATH    "./"
+#define PATH    "/bin/"
 #else
 #define PATH    "bin/"
 #endif

--- a/src/include/mwconfig.h
+++ b/src/include/mwconfig.h
@@ -55,7 +55,7 @@
 #define NUKLEARUI		1		/* =0 to use older tan windows-style 3d window frame drawing/colors*/
 #define OUTLINE_MOVE	1		/* =1 draw outline only during window move*/
 #define NO_AUTO_MOVE	1		/* =1 don't auto position window on new windows*/
-#define BIN_NANOX       "/root/nano-X"    /* location of Nano-X for AUTO_START_SERVER */
+#define BIN_NANOX       "/bin/nano-X"    /* location of Nano-X for AUTO_START_SERVER */
 #endif
 
 /* Changeable limits and options*/

--- a/src/nanox/client.c
+++ b/src/nanox/client.c
@@ -442,6 +442,9 @@ GrClose(void)
 	close(nxSocket);
 	nxSocket = -1;
 	LOCK_FREE(&nxGlobalLock);
+#if ELKS
+	GrDelay(200); /* partial raw terminal fix, allow nano-X to run to reset terminal */
+#endif
 }
 
 /**

--- a/src/nanox/srvmain.c
+++ b/src/nanox/srvmain.c
@@ -577,8 +577,8 @@ again:
 		GdTimeout();
 #endif
 #endif /* NONETWORK */
-	} else if(errno != EINTR)
-		EPRINTF("Select() call in main failed: %d\n", errno);
+	} /*else if(errno != EINTR)
+		EPRINTF("Select() call in main failed: %d\n", errno);*/
 }
 
 /********************************************************************************/

--- a/src/nanox/srvnet.c
+++ b/src/nanox/srvnet.c
@@ -2212,7 +2212,7 @@ int GsWrite(int fd, void *buf, int c)
 	while(n < c) {
 		e = write(fd, ((char *) buf + n), (c - n));
 		if(e <= 0) {
-			/*DPRINTF("nano-X: GsWrite failed %d\n", fd);*/
+			/*EPRINTF("nano-X: GsWrite failed %d\n", fd);*/
 			GsClose(fd);
 			return -1;
 		}


### PR DESCRIPTION
Nano-X binaries are now copied to ELKS /bin, rather than /root. 

Since nxstart is not in /bin, to start Nano-X use:
```
# nxstart
```
without having to run ./nxstart as before.

Partially fixes the appearance of a shell hang on exit from nxstart, as reported by @toncho11 in https://github.com/ghaerr/elks/pull/2228#issuecomment-2661330717. This turns out to be an issue with the shell having problems reading the terminal that was reset to RAW mode by nano-X. Typing ^C after exit will bring the prompt back.

This PR partially fixes the appeared hang on exit from nxstart - which will now work but only when nxstart is the last window to be closed in Nano-X. A long term fix will come later.

