### PR TITLE
[pc98] Add cursor on and off when open and close

### DIFF
--- a/src/drivers/scr_pc98.c
+++ b/src/drivers/scr_pc98.c
@@ -134,6 +134,18 @@ void int_A3(unsigned int l_seg)
                       "pop %ds;");
 }
 
+void cursor_on()
+{
+    __asm__ volatile ("mov $17,%ah;"
+                      "int $0x18;");
+}
+
+void cursor_off()
+{
+    __asm__ volatile ("mov $18,%ah;"
+                      "int $0x18;");
+}
+
 static PSD
 PC98_open(PSD psd)
 {
@@ -148,6 +160,8 @@ PC98_open(PSD psd)
 	unsigned int __far *tvram;
 
 	extern PSUBDRIVER pc98plan4[4];
+
+	cursor_off();
 
 	// Clear 80*25 words text vram starting from segment 0xA000
 	tvram = (unsigned int __far *) _MK_FP(0xA000,0);
@@ -232,6 +246,8 @@ PC98_close(PSD psd)
 {
 	outb(0x0C,0xA2);   // GDC Stop
 	outb(0x0A,0x68);   // Code Access for font
+
+	cursor_on();
 }
 
 static void

--- a/src/nanox/srvmain.c
+++ b/src/nanox/srvmain.c
@@ -373,7 +373,15 @@ GsSelect(GR_TIMEOUT timeout)
 	int	fd;
 #endif
 
-#if ELKS
+#if CONFIG_ARCH_PC98
+	if (GsCheckMouseEvent())
+		return;
+	if (mousedev.Poll())
+	{
+		GsCheckMouseEvent();
+		return;
+	}
+#elif ELKS
     /*
      * Process any mouse events queued after last select.
      * This prevents hangin on select until next real event.
@@ -381,13 +389,6 @@ GsSelect(GR_TIMEOUT timeout)
      */
 	if (mouse_fd >= 0 && GsCheckMouseEvent())
 		return;
-#endif
-#if CONFIG_ARCH_PC98
-	if (mousedev.Poll())
-	{
-		GsCheckMouseEvent();
-		return;
-	}
 #endif
 	/* X11/SDL perform single update of aggregate screen update region*/
 	if (scrdev.PreSelect)


### PR DESCRIPTION
Hello @ghaerr 

The cursor on and off codes worked.

CTRL-A worked well to stop graphic mode so I don't need to modify for this.

I haven't fixed mouse_fd yet.
https://github.com/ghaerr/microwindows/commit/9cc339c23abbf5a31c0a19911b47cf220c97d334#commitcomment-152880216

Thank you.

