### PR TITLE
Speed up mouse cursor and VGA display for slow 8088 systems

### DIFF
--- a/src/Makefile.elks
+++ b/src/Makefile.elks
@@ -72,7 +72,7 @@ NANOX = nanox/srvmain.o nanox/srvfunc.o nanox/srvutil.o nanox/srvevent.o \
 NANOX += nanox/wmaction.o nanox/wmclients.o nanox/wmevents.o nanox/wmutil.o
 ENGINE = engine/devdraw.o engine/devmouse.o engine/devkbd.o engine/devclip1.o \
 	engine/devopen.o engine/devfont.o engine/devlist.o engine/devblit.o \
-    engine/devtimer.o engine/devpal1.o engine/devpal4.o
+    engine/devpal1.o engine/devpal4.o
 
 ALL = lib/libnano-X.a nxdemos
 

--- a/src/Makefile.elks
+++ b/src/Makefile.elks
@@ -14,6 +14,17 @@ CONFIG_ARCH_PC98=n
 
 # remove any -mregparmcall as ASM files need cdecl calling convention
 CFLAGS := $(filter-out -mregparmcall, $(CFLAGS))
+CFLAGS += -O2
+CFLAGS += -fno-align-jumps
+CFLAGS += -fno-align-functions
+CFLAGS += -fno-align-loops
+CFLAGS += -fno-align-labels
+CFLAGS += -fira-region=one
+CFLAGS += -fira-hoist-pressure
+CFLAGS += -freorder-blocks-algorithm=simple
+CFLAGS += -fno-reorder-blocks
+CFLAGS += -fno-prefetch-loop-arrays
+CFLAGS += -fno-tree-ch
 CFLAGS += -DELKS=1 -DUNIX=1 -DNDEBUG=1
 CFLAGS += -DMWPIXEL_FORMAT=MWPF_PALETTE -DSCREEN_PIXTYPE=MWPF_PALETTE
 CFLAGS += -DUSE_SMALL_CURSOR=1

--- a/src/drivers/mou_ser.c
+++ b/src/drivers/mou_ser.c
@@ -27,7 +27,7 @@
 #define SGTTY		0	/* set to use sgtty serial port control*/
 #define SLOW_CPU        0       /* =1 discard already-read mouse input on slow systems */
 
-#define	SCALE		3	/* default scaling factor for acceleration */
+#define	SCALE		2	/* default scaling factor for acceleration */
 #define	THRESH		5	/* default threshhold for acceleration */
 
 #if TERMIOS

--- a/src/drivers/vgaplan4_mem.c
+++ b/src/drivers/vgaplan4_mem.c
@@ -215,7 +215,7 @@ vga_to_vga_blit(PSD dstpsd, MWCOORD dstx, MWCOORD dsty, MWCOORD w, MWCOORD h,
 			set_write_planes(1 << plane);
 
 			/* FIXME: only works if srcx and dstx are same modulo*/
-			if(x1/8 == x2/8) {
+			if((x1>>3) == (x2>>3)) {
 		  		select_and_set_mask((0xff >> (x1 & 7)) & (0xff << (7 - (x2 & 7))));
 				PUTBYTE_FP(d, GETBYTE_FP(s));
 			} else {

--- a/src/drivers/vgaplan4_vga.c
+++ b/src/drivers/vgaplan4_vga.c
@@ -76,7 +76,7 @@ vga_drawpixel(PSD psd, MWCOORD x, MWCOORD y, MWPIXELVAL c)
 	set_op(mode_table[gr_mode]);
 	set_color ((int)c);
 	select_and_set_mask (mask[x&7]);
-	RMW_FP ((FARADDR)SCREENBASE + (x>>3) + y * BYTESPERLINE);
+	RMW_FP ((FARADDR)SCREENBASE + (y<<6) + (y<<4) + (x>>3)); /* y*80 + x / 8 */
 	DRAWOFF;
 }
 
@@ -92,7 +92,7 @@ vga_readpixel(PSD psd, MWCOORD x, MWCOORD y)
 	assert (y >= 0 && y < psd->yres);
   
 	DRAWON;
-	src = (unsigned char FAR *)(SCREENBASE + (x>>3) + y * BYTESPERLINE);
+	src = (unsigned char FAR *)(SCREENBASE + (y<<6) + (y<<4) + (x>>3));
 	for(plane=0; plane<4; ++plane) {
 		set_read_plane(plane);
 		if(GETBYTE_FP(src) & mask[x&7])
@@ -123,7 +123,7 @@ vga_drawhorzline(PSD psd, MWCOORD x1, MWCOORD x2, MWCOORD y, MWPIXELVAL c)
 	* for some reason.  So, we use the equivalent slower drawpixel
 	* method when not drawing MWROP_COPY.
 	*/
-	dst = (unsigned char FAR *)(SCREENBASE + (x1>>3) + y*BYTESPERLINE);
+	dst = (unsigned char FAR *)(SCREENBASE + (y<<6) + (y<<4) + (x1>>3));
 	if(gr_mode == MWROP_COPY) {
 		if ((x1>>3) == (x2>>3)) {
 			select_and_set_mask ((0xff >> (x1 & 7)) & (0xff << (7 - (x2 & 7))));
@@ -168,7 +168,7 @@ vga_drawvertline(PSD psd, MWCOORD x, MWCOORD y1, MWCOORD y2, MWPIXELVAL c)
 	set_op(mode_table[gr_mode]);
 	set_color ((int)c);
 	select_and_set_mask (mask[x&7]);
-	dst = (unsigned char FAR *)(SCREENBASE + (x>>3) + y1 * BYTESPERLINE);
+	dst = (unsigned char FAR *)(SCREENBASE + (y1<<6) + (y1<<4) + (x>>3));
 	while (y1++ <= y2) {
 		RMW_FP (dst);
 		dst += BYTESPERLINE;

--- a/src/include/mwconfig.h
+++ b/src/include/mwconfig.h
@@ -41,7 +41,7 @@
 #define HAVE_PCF_SUPPORT 0		/* PCF font support*/
 #define POLYREGIONS		0		/* =1 includes polygon regions*/
 #define DYNAMICREGIONS	0		/* =1 to use more complex MWCLIPREGION regions*/
-#define MW_FEATURE_TIMERS 1		/* =1 to include MWTIMER support */
+#define MW_FEATURE_TIMERS 0		/* =1 to include MWTIMER support */
 #define MW_FEATURE_BITMAPS 1	/* =1 to enable GrBitmap */
 #define MW_FEATURE_IMAGES 0		/* =1 to enable GdLoadImage/GdDrawImage etc*/
 #define MW_FEATURE_SHAPES 0		/* =1 for arc, ellipse, polygons, tile/stipple*/

--- a/src/nanox/srvmain.c
+++ b/src/nanox/srvmain.c
@@ -460,9 +460,9 @@ GsSelect(GR_TIMEOUT timeout)
 #else
 		if (timeout)				/* setup mwin poll timer*/
 		{
-			/* convert wait timeout to timeval struct*/
-			tout.tv_sec = timeout / 1000;
-			tout.tv_usec = (timeout % 1000) * 1000;
+			/* convert wait timeout to timeval struct - approximation for speed for 8088*/
+			tout.tv_sec = timeout >> 10;
+			tout.tv_usec = (timeout & 0x3FF) << 10;
 		}
 		else
 #endif

--- a/src/nanox/srvmain.c
+++ b/src/nanox/srvmain.c
@@ -882,28 +882,29 @@ GsInitialize(void)
 #define MASK(a,b,c,d,e,f,g) \
         (((((((((((((a * 2) + b) * 2) + c) * 2) + d) * 2) \
         + e) * 2) + f) * 2) + g) << 9)
-	static MWIMAGEBITS cursormask[8];
-	static MWIMAGEBITS cursorbits[8];
-
+/* Small 8x8 cursor for machines to slow for 16x16 cursors */
 #define HOTX    1
 #define HOTY    1
 #define CURSW   8
 #define CURSH   8
-    cursormask[0] = MASK(X,X,X,X,X,X,_);
-    cursormask[1] = MASK(X,X,X,X,X,_,_);
-    cursormask[2] = MASK(X,X,X,X,_,_,_);
-    cursormask[3] = MASK(X,X,X,X,X,_,_);
-    cursormask[4] = MASK(X,X,X,X,X,X,_);
-    cursormask[5] = MASK(X,_,_,X,X,X,X);
-    cursormask[6] = MASK(_,_,_,_,X,X,X);
-
-    cursorbits[0] = MASK(_,_,_,_,_,_,_);
-    cursorbits[1] = MASK(_,X,X,X,X,_,_);
-    cursorbits[2] = MASK(_,X,X,X,_,_,_);
-    cursorbits[3] = MASK(_,X,X,X,_,_,_);
-    cursorbits[4] = MASK(_,X,_,X,X,_,_);
-    cursorbits[5] = MASK(_,_,_,_,X,X,_);
-    cursorbits[6] = MASK(_,_,_,_,_,X,X);
+	static MWIMAGEBITS cursormask[8] = {
+	    MASK(X,X,X,X,X,X,_),
+	    MASK(X,X,X,X,X,_,_),
+	    MASK(X,X,X,X,_,_,_),
+	    MASK(X,X,X,X,X,_,_),
+	    MASK(X,X,X,X,X,X,_),
+	    MASK(X,_,_,X,X,X,X),
+	    MASK(_,_,_,_,X,X,X)
+	};
+	static MWIMAGEBITS cursorbits[8] = {
+	    MASK(_,_,_,_,_,_,_),
+	    MASK(_,X,X,X,X,_,_),
+	    MASK(_,X,X,X,_,_,_),
+	    MASK(_,X,X,X,_,_,_),
+	    MASK(_,X,_,X,X,_,_),
+	    MASK(_,_,_,_,X,X,_),
+	    MASK(_,_,_,_,_,X,X)
+	};
 #else
 #define HOTX    0
 #define HOTY    0

--- a/src/nanox/srvmain.c
+++ b/src/nanox/srvmain.c
@@ -369,9 +369,6 @@ GsSelect(GR_TIMEOUT timeout)
 	int	setsize = 0;
 	struct timeval tout;
 	struct timeval *to;
-#if NONETWORK
-	int	fd;
-#endif
 
 #if CONFIG_ARCH_PC98
 	if (GsCheckMouseEvent())
@@ -418,7 +415,7 @@ GsSelect(GR_TIMEOUT timeout)
 	}
 #if NONETWORK
 	/* handle registered input file descriptors*/
-	for (fd = 0; fd < regfdmax; fd++)
+	for (int fd = 0; fd < regfdmax; fd++)
 	{
 		if (!FD_ISSET(fd, &regfdset))
 			continue;
@@ -508,7 +505,7 @@ again:
 
 #if NONETWORK
 		/* check for input on registered file descriptors */
-		for (fd = 0; fd < regfdmax; fd++)
+		for (int fd = 0; fd < regfdmax; fd++)
 		{
 			GR_EVENT_FDINPUT *	gp;
 


### PR DESCRIPTION
Brings over some of the changes made for ELKS Paint in https://github.com/ghaerr/elks/pull/2277 to speed up drawing.

The mouse cursor show/hide routines now only save and redraw bits set in the cursor mask. This is much faster since each 16x16 or 8x8 cursor pixel is drawn individually using drawpixel.

C constructs like x/8 or y*80 are replaced with left/right shifts in the VGA screen driver. This is because the compiler used, ia16-elf-gcc, only works well when optimizing for size (-Os) and as such emits DIV and MUL instructions for the examples respectively, which are very slow on 8088. When -Os is set, unfortunately even certain left shifts (such as (y<<6) + (y<<4)) are actually replaced ("optimized") with y * 80 and a MUL still produced. Nonetheless, the C code is changed now until a workaround for optimization level 3 (-O3) is found that doesn't produce faulty code.