### PR TITLE
nxscribble: fix parameters defaults to int which leads to error on newer systems

### DIFF
--- a/src/demos/nxscribble/bitvector.c
+++ b/src/demos/nxscribble/bitvector.c
@@ -35,6 +35,7 @@ BitVector bv;
 
 char *
 BitVectorToString(max, bv)
+int max;
 BitVector bv;
 {
 	char *string = tempstring();

--- a/src/demos/nxscribble/sc.c
+++ b/src/demos/nxscribble/sc.c
@@ -241,6 +241,7 @@ Vector fv;
 sClassDope
 sClassifyAD(sc, fv, ap, dp)
 sClassifier sc;
+int fv;
 double *ap;
 double *dp;
 {

--- a/src/demos/nxscribble/util.c
+++ b/src/demos/nxscribble/util.c
@@ -66,6 +66,7 @@ char *s;
 void
 error(a, b, c, d, e, f, g, h, i, j)
 char *a;
+int  b, c, d, e, f, g, h, i, j;
 {
 	sprintf(err_msg, a, b, c, d, e, f, g, h, i, j);
 	li_err_msg = err_msg;
@@ -78,6 +79,7 @@ char *a;
 void
 exit_error(a, b, c, d, e, f, g, h, i, j)
 char *a;
+int  b, c, d, e, f, g, h, i, j;
 {
 	GrError( a, b, c, d, e, f, g, h, i, j);
 	exit(1);
@@ -93,6 +95,7 @@ int	DebugFlag = 1;
 void
 debug(a, b, c, d, e, f, g)
 char *a;
+int  b, c, d, e, f, g;
 {
 	if(DebugFlag)
 		GrError( a, b, c, d, e, f, g);


### PR DESCRIPTION
after switching to the development base move to Debian Trixie.

SuiTk - [https://gitlab.com/pikron/sw-base/suitk](https://gitlab.com/pikron/sw-base/suitk)
builds with current Microwindows and runs on the Debian Trixie under X11 native,
and the SuiTk build for embedded targets (still with old Microwindows) seems to be viable
when the details of the more strict GCC diagnostics are resolved (experimentally/locally
for now only.

Please apply these minor changes to make using Microwidows on Debian Trixie
easier for others. In the longer term, remaining function declarations in Kernighan
and Ritchie style should be converted to ANSI format to make building easier
with newer toolchains.