### PR TITLE
[driver] fix bit order of vga to vga blit on pc-98

### DIFF
--- a/src/drivers/vgaplan4_mem_pc98.c
+++ b/src/drivers/vgaplan4_mem_pc98.c
@@ -227,12 +227,12 @@ vga_to_vga_blit(PSD dstpsd, MWCOORD dstx, MWCOORD dsty, MWCOORD w, MWCOORD h,
 
 			/* FIXME: only works if srcx and dstx are same modulo*/
 			if((x1>>3) == (x2>>3)) {
-				mask_b = (0xff << (x1 & 7)) & (0xff >> (7 - (x2 & 7)));
+				mask_b = (0xff >> (x1 & 7)) & (0xff << (7 - (x2 & 7)));
 				src_b = GETBYTE_FP(s) & mask_b;
 				dst_b = GETBYTE_FP(d) & ~mask_b;
 				PUTBYTE_FP(d, src_b | dst_b);
 			} else {
-				mask_b = (0xff << (x1 & 7));
+				mask_b = (0xff >> (x1 & 7));
 				src_b = GETBYTE_FP(s) & mask_b;
 				dst_b = GETBYTE_FP(d) & ~mask_b;
 				PUTBYTE_FP(d, src_b | dst_b);
@@ -242,7 +242,7 @@ vga_to_vga_blit(PSD dstpsd, MWCOORD dstx, MWCOORD dsty, MWCOORD w, MWCOORD h,
 				for (i = (x2 - (x1&~7)) >> 3; i > 1; i--)   /* while x1+1 < x2 */
 					PUTBYTE_FP(d++, GETBYTE_FP(s++));
 
-				mask_b = (0xff >> (7 - (x2 & 7)));
+				mask_b = (0xff << (7 - (x2 & 7)));
 				src_b = GETBYTE_FP(s) & mask_b;
 				dst_b = GETBYTE_FP(d) & ~mask_b;
 				PUTBYTE_FP(d, src_b | dst_b);


### PR DESCRIPTION
Hello @ghaerr 

I needed to fix the shift of the vga to vga blit on pc-98
since the bit order of pc-98 vram is the reverse of the ibm pc.

This PR fixes the corruption of the first character on the left side of nxterm.

Before fix
 
<img width="644" height="478" alt="Screenshot from 2025-09-20 16-41-30" src="https://github.com/user-attachments/assets/90f917fa-899d-4fba-b938-e16c2275f195" />

After fix

<img width="644" height="478" alt="Screenshot from 2025-09-20 17-14-08" src="https://github.com/user-attachments/assets/a6981aa8-9021-4fda-98fc-21a70c68df9a" />

Thank you!


