### PR TITLE
Add VGA hardware XOR 16x16 cursor draw code from ELKS Paint

### DIFF
--- a/src/Makefile.elks
+++ b/src/Makefile.elks
@@ -27,7 +27,6 @@ CFLAGS += -fno-prefetch-loop-arrays
 CFLAGS += -fno-tree-ch
 CFLAGS += -DELKS=1 -DUNIX=1 -DNDEBUG=1
 CFLAGS += -DMWPIXEL_FORMAT=MWPF_PALETTE -DSCREEN_PIXTYPE=MWPF_PALETTE
-CFLAGS += -DUSE_SMALL_CURSOR=1
 CFLAGS += -Iinclude -Ielksdrivers -I$(TOPDIR)/cross/lib/gcc/ia16-elf/6.3.0/include
 CFLAGS += -Wno-unused-variable -Wno-unused-but-set-variable
 CFLAGS += -Wno-missing-field-initializers
@@ -36,6 +35,7 @@ AR = ia16-elf-ar
 # screen, mouse and kbd drivers
 ifeq ($(CONFIG_ARCH_PC98), y)
 CFLAGS += -DCONFIG_ARCH_PC98=1
+CFLAGS += -DUSE_SMALL_CURSOR=1
 DRIVERS += drivers/scr_pc98.o drivers/vgaplan4_pc98.o drivers/vgaplan4_mem_pc98.o
 DRIVERS += drivers/mou_pc98.o drivers/kbd_tty.o
 #DRIVERS += drivers/ramfont.o
@@ -46,10 +46,12 @@ DRIVERS += drivers/mou_ser.o drivers/kbd_tty.o
 DRIVERS += drivers/vgaplan4_asm.o
 
 ifeq ($(SCREEN_CGA), y)
+CFLAGS += -DUSE_SMALL_CURSOR=1
 DRIVERS += drivers/scr_cga.o drivers/vgaplan4_cga.o drivers/vgaplan4_mem.o
 #DRIVERS += drivers/ramfont.o
 else
 # EGA/VGA screen driver
+CFLAGS += -DUSE_VGA_XOR_CURSOR=1
 DRIVERS += drivers/scr_vga.o drivers/vgaplan4_vga.o drivers/vgaplan4_mem.o
 #DRIVERS += elksdrivers/romfont.o
 endif


### PR DESCRIPTION
Ports fast hardware VGA XOR cursor drawing code from ELKS Paint to Microwindows and Nano-X for real mode ELKS using the VGA screen driver. Continues mouse cursor speedup discussed in #123. This allows an easier-to-see 16x16 cursor, which appears different based on the colors over which the cursor is being drawn.

This uses hardware specific to VGA; the PC98 and IBM PC CGA ports continue to use the 8x8 cursor for speed reasons.

Here's some screenshots of the cursor on ELKS/QEMU:
<img width="752" height="620" alt="Screenshot 2025-10-27 at 7 33 01 PM" src="https://github.com/user-attachments/assets/654084d1-e8f2-474c-b746-73596700eb79" />
<img width="752" height="620" alt="Screenshot 2025-10-27 at 7 33 14 PM" src="https://github.com/user-attachments/assets/fbed2e1c-8e56-4d44-9e8d-fe92b150e424" />
