### PR TITLE
[nxjpeg] 8 color grayscale mode

### DIFF
--- a/src/demos/nanox/nxjpeg.c
+++ b/src/demos/nanox/nxjpeg.c
@@ -63,15 +63,6 @@
  *   7/12/2025 version 1.1 added 8 color gray scaled mode
  */
 
-/*
- * nxjpeg - Nano-X JPEG viewer for VGA (optimized for low memory and ELKS)
- *
- * Uses PicoJPEG (MCU-by-MCU) and draws to a Nano-X VGA window. 
- * Nano X on VGA supports only 16 colors.
- *
- * --- (unchanged header omitted for brevity) ---
- */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
<img alt="gray8c" src="https://github.com/user-attachments/assets/c483ba7d-c9fc-47c3-be3a-d2f909bbcddd" />

Added -8 mode in -g mode for 8 color grayscale. This has improved the quality of grayscaled images.
Once Nano X server is updated to support palette changes, this code will be updated. In the meantime I would like people to start testing it - quality of images, speed, etc.
I took special care not to affect the UI colors of Nano X, avoiding the main EGA UI entries used by Nano X.
Also Nano X could provide a method get_UI_palette in the future specifying the subset of colors that are used by the UI.
Anyway, please accept this patch, it will be improved in the future.