### PR TITLE
Fix nxterm shell waiting for CR when executing startup command

### DIFF
--- a/src/demos/nanox/nxterm.c
+++ b/src/demos/nanox/nxterm.c
@@ -1141,7 +1141,7 @@ term(void)
 	if (startprogram) {
 		usleep(1000);
 		write(termfd, startprogram, strlen(startprogram));
-		write(termfd, "\n", 1);
+		write(termfd, "\r", 1);
 	}
 
 	while (42) {


### PR DESCRIPTION
This finally worked and allows:

`nxterm "edit /etc/hosts && exit"` on ELKS.