### PR TITLE
Fix various exit problems with nxterm and nano-X

### DIFF
--- a/src/demos/nanox/nxterm.c
+++ b/src/demos/nanox/nxterm.c
@@ -1597,6 +1597,7 @@ static void sigpipe(int sig)
 	/* this one musn't close the window */
 	/*_write_utmp(pty, "", "", 0);  */
 	kill(-pid, SIGHUP);
+	GrClose();
 	_exit(sig);
 }
 
@@ -1604,6 +1605,7 @@ static void sigpipe(int sig)
 static void sigchld(int sig)
 {
 	/*  _write_utmp(pty, "", "", 0);  */
+	GrClose();
 	_exit(sig);
 }
 
@@ -1611,15 +1613,14 @@ static void sigchld(int sig)
 static void sigquit(int sig)
 {
 	signal(sig, SIG_IGN);
+	GrClose();
 	kill(-pid, SIGHUP);
 }
 #endif /* UNIX*/
 
 int main(int argc, char **argv)
 {
-    char *shell = NULL, *cptr;
     GR_CURSOR_ID c1;
-    char thesh[128];
     GR_BITMAP	bitmap1fg[7];	/* mouse cursor */
     GR_BITMAP	bitmap1bg[7];
 
@@ -1663,21 +1664,16 @@ int main(int argc, char **argv)
     /*
      * now *argv either points to a program to start or is zero
      */
-#ifdef __FreeBSD__ 
-    /* now UNIX98 - shell is passed in FreeBSD only */
-    if (*argv)
-		shell = *argv;
-#else
     if (*argv)
         startprogram = *argv++;
-#endif
 
+#if UNUSED
+    char *shell = NULL, *cptr;
+    char thesh[128];
     if (!shell)
 		shell = getenv("SHELL=");
-#if !ELKS
     if (!shell)
 		shell = pw->pw_shell;
-#endif
     if (!shell)
 		shell = "/bin/sh";
 
@@ -1691,6 +1687,7 @@ int main(int argc, char **argv)
 		sprintf (thesh, "-%s", cptr ? cptr + 1 : shell);
 		*--argv = thesh;
     }
+#endif
 
     col = stdcol;
     row = stdrow;

--- a/src/include/mwconfig.h
+++ b/src/include/mwconfig.h
@@ -34,7 +34,7 @@
 #define NANOWM			1		/* =1 for builtin nano-X window manager*/
 #define USE_ALLOCA		0		/* =1 if alloca() is available*/
 #define HAVE_MMAP       0       /* =1 has mmap system call*/
-#define HAVE_SIGNAL		0		/* =1 has signal system call*/
+#define HAVE_SIGNAL		1		/* =1 has signal system call*/
 #define HAVE_FILEIO		0		/* =1 to include libc stdio and image reading routines*/
 #define HAVE_BMP_SUPPORT 0		/* BMP image support*/
 #define HAVE_FNT_SUPPORT 0		/* Microwindows FNT font support*/

--- a/src/nanox/client.c
+++ b/src/nanox/client.c
@@ -444,7 +444,7 @@ GrClose(void)
 	nxSocket = -1;
 	LOCK_FREE(&nxGlobalLock);
 #if ELKS
-	GrDelay(200); /* partial raw terminal fix, allow nano-X to run to reset terminal */
+	GrDelay(500); /* partial raw terminal fix, allow nano-X to run to reset terminal */
 #endif
 }
 

--- a/src/nanox/srvmain.c
+++ b/src/nanox/srvmain.c
@@ -1064,5 +1064,8 @@ GsTerminate(void)
 #if VTSWITCH
 	MwRedrawVt(mwvterm);
 #endif
+#if ELKS
+	write(1, "\033[25;1H", 7);
+#endif
 	_exit(0);
 }


### PR DESCRIPTION
Fixes a problem on the ELKS console after `nxterm` exits, the shell prompt is not displayed until ^C is typed. This required a bit more time spent in nxterm exiting for /bin/sh to change termios settings, as well as having nxterm call GrClose in all exit situations. The cursor is now always displayed on the last line of the console after nano-x exit.

Also turns on signal handling in ELKS `nano-x` which was causing it to crash when exiting nxterm in certain circumstances. Identified in https://github.com/toncho11/microwindows/issues/5.

@toncho11, this should fix both of your earlier reported problems of using `nxterm "edit /etc/mount.cfg && exit"`. Actually it's pretty cool to quickly be able to pull up a graphical terminal session and editor from the ELKS shell prompt. Things should go a lot smoother now.

Also previously `nxterm` changed its name to `-sh` in `ps` listings; this has been removed so it shows as `nxterm`. The shell running behind its pseudo terminal continues to run as `/bin/sh`, but with `/dev/ttyp0` as the terminal.