### PR TITLE
Make nxstart wait for all other apps to finish before exiting to shell

### DIFF
--- a/src/demos/nanox/nxjpeg.c
+++ b/src/demos/nanox/nxjpeg.c
@@ -813,6 +813,7 @@ static void VGA_WriteEGAColorRaw(int index, int ega)
     outb(0x3C0, ega & 0x3F);
 }
 
+#if UNUSED
 static void VGA_WriteEGAColor(int index, int r, int g, int b)
 {
     int rr = (r >> 6) & 3;
@@ -827,6 +828,7 @@ static void VGA_WriteEGAColor(int index, int r, int g, int b)
     inb(0x3DA);
     outb(0x3C0, 0x20);
 }
+#endif
 
 void CustomGrSetSystemPalette(const GR_PALETTE *pal_in)
 {

--- a/src/demos/nanox/nxstart.c
+++ b/src/demos/nanox/nxstart.c
@@ -124,7 +124,6 @@ main(int argc,char **argv)
 	GR_EVENT	event;		/* current event */
 	struct app_info	* act;
 	int		width = 8, height;
-
 #ifdef USE_WEIRD_POINTER
 	GR_BITMAP	bitmap1fg[7];	/* bitmaps for first cursor */
 	GR_BITMAP	bitmap1bg[7];
@@ -209,7 +208,16 @@ main(int argc,char **argv)
 				do_mouse(&event.mouse);
 				break;
 			case GR_EVENT_TYPE_CLOSE_REQ:
+				signal(SIGCHLD, SIG_IGN);
 				GrClose();
+				/*
+				 * Wait for all children to exit before we do.
+				 * This prevents the shell we return to from reading
+				 * simultaneously with nxterm or another NX app and
+				 * causing bad behaviour.
+				 */
+				while (waitpid(-1, NULL, 0) != -1)
+					continue;
 				return 0;
 		}
 	}


### PR DESCRIPTION
Should fix problem with sometimes requiring ^C in shell when `nxterm` exits after `nxstart`.

Identified in https://github.com/ghaerr/microwindows/pull/151#issuecomment-3647986529.

In general, it is now recommended that `nxstart` be used to start longer sessions of Nano-X, since `nxstart` can properly control the exit sequence back to the shell and wait for all processes to exit first. It is still OK to run `nxterm "edit && exit"` etc, but that should only be done for shorter sessions, rather than as a general means of starting the Nano-X environment for other NX programs.

@toncho11, try this out. The problem you identified seems to occur when `nxstart` is exited before `nxterm`. I can't get it to fail anymore, please report new instances of failure here.

Also cleans up compiler warning in nxjpeg.c for unused function.