### PR TITLE
Fix child reap bug in nxstart, nxlaunch for ELKS

### DIFF
--- a/src/demos/nanox/nxlaunch.c
+++ b/src/demos/nanox/nxlaunch.c
@@ -73,17 +73,11 @@
 /* This needs to be global so the signal handler can get to it. */
 pid_t sspid;
 
-#ifndef WAIT_ANY
-/* For Cygwin.  See:
- * http://www.opengroup.org/onlinepubs/007908799/xsh/wait.html
- */
-#define WAIT_ANY (pid_t)-1
-#endif
-
 void reaper(int signum) {
 	pid_t pid;
 
-	while((pid = waitpid(WAIT_ANY, NULL, WNOHANG) > 0))
+	signal(SIGCHLD, &reaper);
+	while((pid = waitpid(-1, NULL, WNOHANG) > 0))
 		if(pid == sspid) sspid = -1;
 }
 


### PR DESCRIPTION
Further problems were found with `nxstart` not properly waiting for its zombie children when one of its forked commands exited. The system will send a SIGCHLD signal after upon a child process exit. In ELKS, the signal must be re-armed each invocation, so nxstart was only working properly on the first child exit. A child process's exit status is kept is kept in the task structure in ELKS, and failure to "reap" a child properly can resulting running out of task entries for new processes.

A similar problem was found in nxlaunch (not available yet for ELKS).

Some source code cleanup also performed, and an extra `waitpid` removed for ELKS, which was only needed because of the previous incorrect child exit handling.