### PR TITLE
Add ANSI Device Status Report handling in nxterm.c to report rols/cols

### DIFF
--- a/src/demos/nanox/nxterm.c
+++ b/src/demos/nanox/nxterm.c
@@ -612,6 +612,7 @@ void rendition(int escvalue) {
 void esc100(unsigned char c)	/* various ANSI control codes */
 {
     int y, yy;
+    char buf[32];
 //leave escstate=10 till done. This states gets this function called.
 
 static int escvalue1,escvalue2,escvalue3;
@@ -948,6 +949,10 @@ scrolltop, scrollbottom = upper and lower scroll region limit in lines/rows
 		if (escvalue1==25) hide_cursor();
 		break;
 
+    case 'n':/* DSR device status report */
+		sprintf(buf, "\033[%d;%dR", cury + 1, curx + 1);
+		write(termfd, buf, strlen(buf));
+		break;
     default: /* unknown escape sequence */
 		break;
     }


### PR DESCRIPTION
Adds ANSI DSR reporting to nxterm, which allows running ELKS `sl`, `fm`, and other TUI programs that request the environment columns and rows to operate properly.

Previously these programs would hang waiting for a keystroke which was actually the program waiting for the DSR reponse, whcih is implemented in the ELKS console and most ANSI emulators.

Reported initially by @tyama501 in https://github.com/ghaerr/elks/discussions/1810#discussioncomment-14328167.