### PR TITLE
nxclock: Initialize timezone in do_clock to 0

### DIFF
--- a/src/demos/nanox/nxclock.c
+++ b/src/demos/nanox/nxclock.c
@@ -259,7 +259,7 @@ void
 do_clock(void)
 {
 	struct timeval tv;
-	struct timezone tz;
+	struct timezone tz = {0};
 	struct tm * tp;
 	time_t now;
 	int minutes, hour, sec;


### PR DESCRIPTION
GlibC gettimeofday zeroes out the tz argument passed to it in comparison with musl which doesn't touch it. This variable is on the stack and it can contain garbage that is then used to calculate and draw time. implicitly zero `tz` out so the clock program doesn't show the wrong time.

https://elixir.bootlin.com/glibc/glibc-2.43.9000/source/time/gettimeofday.c#L26
https://elixir.bootlin.com/musl/v1.2.6/source/src/time/gettimeofday.c#L5

Compiling microwindows with a musl toolchain brings the following result when opening clock.
Some runs are correct and some are completely wrong. Setting to 0 fixes the issue.
<img width="2400" height="1350" alt="image" src="https://github.com/user-attachments/assets/69dc9492-c7ec-43c0-8e32-11a0ba681aa7" />
