### PR TITLE
Enable ANSI sequence translation in TTY kbd driver for ELKS

### DIFF
--- a/src/Makefile.elks
+++ b/src/Makefile.elks
@@ -30,6 +30,7 @@ CFLAGS += -fno-prefetch-loop-arrays
 CFLAGS += -fno-tree-ch
 CFLAGS += -DELKS=1 -DUNIX=1 -DNDEBUG=1
 CFLAGS += -DMWPIXEL_FORMAT=MWPF_PALETTE -DSCREEN_PIXTYPE=MWPF_PALETTE
+CFLAGS += -DTRANSLATE_ESCAPE_SEQUENCES=1
 CFLAGS += -Iinclude -Ielksdrivers -I$(TOPDIR)/cross/lib/gcc/ia16-elf/6.3.0/include
 CFLAGS += -Wno-unused-variable -Wno-unused-but-set-variable
 CFLAGS += -Wno-missing-field-initializers

--- a/src/demos/nanox/nxterm.c
+++ b/src/demos/nanox/nxterm.c
@@ -1377,11 +1377,11 @@ int do_special_key_ansi(unsigned char *buffer, int key, int modifier)
 
 	switch (key) {
 	case  MWKEY_LEFT:
-		str="\033OD";
+		str="\033[D";
 		len = 3;
 		break;
 	case MWKEY_RIGHT:
-		str="\033OC";
+		str="\033[C";
 		len=3;
 		break;
 	case MWKEY_UP:
@@ -1390,17 +1390,17 @@ int do_special_key_ansi(unsigned char *buffer, int key, int modifier)
 			len = 0;
 			scrolledFlag=0;
 		} else {
-			str="\033OA";
+			str="\033[A";
 			len=3;
 		}
 		break;
 	case MWKEY_DOWN:
-		str="\033OB";
+		str="\033[B";
 		len=3;
 		break;
 	case MWKEY_HOME:
-		str="\033[1~";
-		len=4;
+		str="\033[H";
+		len=3;
 		break;
 	case MWKEY_INSERT:
 		str="\033[2~";
@@ -1411,8 +1411,8 @@ int do_special_key_ansi(unsigned char *buffer, int key, int modifier)
 		len=3;
 		break;
 	case MWKEY_END:
-		str="\033[4~";
-		len=4;
+		str="\033[F";
+		len=3;
 		break;
 	case MWKEY_KP1:
 		str="\033Oq";

--- a/src/drivers/kbd_tty.c
+++ b/src/drivers/kbd_tty.c
@@ -171,6 +171,13 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 			/* Need more characters - escape sequences are 3+ chars */
 			do {
 				cc = read(fd, buf + buflen, 3 - buflen);
+#if ELKS
+				if (cc == 0 && buflen == 1) {   /* allow lone ESC -> ESC */
+					buflen = 0;
+					mwkey = 27;
+					goto out;
+				}
+#endif
 			} while ((cc < 0) && ((errno == EINTR) || (errno == EAGAIN)));
 			if (cc < 0) {
 				return KBD_FAIL;
@@ -183,6 +190,7 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 		}
 
 		switch (buf[1]) {
+#if !ELKS
 		case 'O': /* Letter O */
 			switch (buf[2]) {
 			case 'P': mwkey = MWKEY_F1; break;
@@ -223,8 +231,10 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 				  break;
 			}
 			break;
+#endif
 		case '[':
 			switch (buf[2]) {
+#if !ELKS
 			case '1':
 				if (buflen < 4)
 					return 0;
@@ -276,12 +286,14 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 			case '6': if (buflen < 4) return 0;
 				  if (buf[3] == '~') mwkey = MWKEY_PAGEDOWN; 
 				  break;
+#endif
 			case 'A': mwkey = MWKEY_UP;    break;
 			case 'B': mwkey = MWKEY_DOWN;  break;
 			case 'C': mwkey = MWKEY_RIGHT; break;
 			case 'D': mwkey = MWKEY_LEFT;  break;
 			case 'F': mwkey = MWKEY_END;   break;
 			case 'H': mwkey = MWKEY_HOME;  break;
+#if !ELKS
 			case '[':
 				if (buflen < 4)
 					return 0;
@@ -302,6 +314,7 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 				case 'E': mwkey = MWKEY_F5; break;
 				}
 				break;
+#endif
 			}
 			break;
 		case 27:
@@ -309,6 +322,7 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 			break;
 		}
 		if (mwkey == 0) {
+#if !ELKS
 			if (buflen >= 5) {
 				EPRINTF("WARNING: Unknown escape sequence ESC '%c' '%c' '%c' '%c'.\n"
 					"(If you're trying to type a real escape, you have to press it 3 times.)\n",
@@ -322,6 +336,7 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 					"(If you're trying to type a real escape, you have to press it 3 times.)\n",
 					buf[1], buf[2]);
 			}
+#endif
 			buflen = 0;
 			return 0;
 		}
@@ -353,7 +368,7 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 	}
 	EPRINTF("Got key: %d\n", mwkey);
 #endif
-
+out:
 	*kbuf = mwkey;		/* no translation*/
 	*modifiers = 0;		/* no modifiers*/
 	*scancode = 0;		/* no scancode*/


### PR DESCRIPTION
Allows desktop ANSI cursor key sequences to be automatically translated to Microwindows/Nano-X proper MWKEY_ values.
Cursor left, right, up, down, home and end are now implemented for ELKS.  To keep the code size small, the larger number of numbered function and other non-arrow keys are not translated at this time.

This was normally only a problem for ELKS, since it uses the non-scan code TTY kbd driver, which has to decode ANSI escape sequences rather than receiving scan codes from the OS.

In addition, `nxterm` is revised to recognize the newly translated arrow key sequences as ANSI rather than the previous VT220 sequences required. This keeps it working properly with the translated MWKEY_ arrow key values now received.

@toncho11, this fixes the arrow keys not working in `nxedit` by translating arrow key sequences in the Nano-X server. 