### PR TITLE
Add NuttX RTOS screen, keyboard and mouse/touchscreen drivers

### DIFF
--- a/src/drivers/Objects.rules
+++ b/src/drivers/Objects.rules
@@ -132,6 +132,23 @@ MW_CORE_OBJS += $(MW_DIR_OBJ)/drivers/mou_ajaguar.o
 MW_CORE_OBJS += $(MW_DIR_OBJ)/drivers/kbd_ajaguar.o
 endif
 
+# NuttX RTOS
+ifeq ($(ARCH), NUTTX)
+MW_CORE_OBJS += $(MW_DIR_OBJ)/drivers/scr_nuttx.o
+ifeq ($(KEYBOARD), NUTTXKBD)
+MW_CORE_OBJS += $(MW_DIR_OBJ)/drivers/kbd_nuttx_event.o
+endif
+ifeq ($(KEYBOARD), NUTTXRAWKBD)
+MW_CORE_OBJS += $(MW_DIR_OBJ)/drivers/kbd_nuttx_raw.o
+endif
+ifeq ($(MOUSE), NUTTXMOUSE)
+MW_CORE_OBJS += $(MW_DIR_OBJ)/drivers/mou_nuttx_mouse.o
+endif
+ifeq ($(MOUSE), NUTTXTOUCH)
+MW_CORE_OBJS += $(MW_DIR_OBJ)/drivers/mou_nuttx_ts.o
+endif
+endif # NUTTX architecture
+
 #### end platforms
 
 ### The following are screen, keyboard and mouse drivers used on non-specific platforms

--- a/src/drivers/kbd_nuttx_common.h
+++ b/src/drivers/kbd_nuttx_common.h
@@ -1,0 +1,132 @@
+#ifndef KBD_NUTTX_COMMON_H
+#define KBD_NUTTX_COMMON_H
+
+#include <nuttx/input/kbd_codec.h>
+#include "mwtypes.h"
+
+static MWKEY translate_keycode(uint32_t code)
+{
+  switch (code)
+    {
+    case KEYCODE_BACKDEL:
+      return MWKEY_BACKSPACE;
+    case KEYCODE_FWDDEL:
+      return MWKEY_DELETE;
+    case KEYCODE_HOME:
+      return MWKEY_HOME;
+    case KEYCODE_END:
+      return MWKEY_END;
+    case KEYCODE_LEFT:
+      return MWKEY_LEFT;
+    case KEYCODE_RIGHT:
+      return MWKEY_RIGHT;
+    case KEYCODE_UP:
+      return MWKEY_UP;
+    case KEYCODE_DOWN:
+      return MWKEY_DOWN;
+    case KEYCODE_PAGEUP:
+      return MWKEY_PAGEUP;
+    case KEYCODE_PAGEDOWN:
+      return MWKEY_PAGEDOWN;
+    case KEYCODE_INSERT:
+      return MWKEY_INSERT;
+    case KEYCODE_ENTER:
+      return MWKEY_ENTER;
+    case KEYCODE_F1:
+      return MWKEY_F1;
+    case KEYCODE_F2:
+      return MWKEY_F2;
+    case KEYCODE_F3:
+      return MWKEY_F3;
+    case KEYCODE_F4:
+      return MWKEY_F4;
+    case KEYCODE_F5:
+      return MWKEY_F5;
+    case KEYCODE_F6:
+      return MWKEY_F6;
+    case KEYCODE_F7:
+      return MWKEY_F7;
+    case KEYCODE_F8:
+      return MWKEY_F8;
+    case KEYCODE_F9:
+      return MWKEY_F9;
+    case KEYCODE_F10:
+      return MWKEY_F10;
+    case KEYCODE_F11:
+      return MWKEY_F11;
+    case KEYCODE_F12:
+      return MWKEY_F12;
+    case KEYCODE_CAPSLOCK:
+      return MWKEY_CAPSLOCK;
+    case KEYCODE_NUMLOCK:
+      return MWKEY_NUMLOCK;
+    case KEYCODE_SCROLLLOCK:
+      return MWKEY_SCROLLOCK;
+    case KEYCODE_PAUSE:
+      return MWKEY_PAUSE;
+    case KEYCODE_PRTSCRN:
+      return MWKEY_PRINT;
+    case KEYCODE_MENU:
+      return MWKEY_MENU;
+
+    default:
+      if (code < 128)
+        {
+          return (MWKEY)code;
+        }
+      return MWKEY_UNKNOWN;
+    }
+}
+
+static void update_modifiers(MWKEYMOD *modifiers, MWKEY key, int press)
+{
+  MWKEYMOD mask = 0;
+
+  switch (key)
+    {
+    case MWKEY_LSHIFT:
+      mask = MWKMOD_LSHIFT;
+      break;
+    case MWKEY_RSHIFT:
+      mask = MWKMOD_RSHIFT;
+      break;
+    case MWKEY_LCTRL:
+      mask = MWKMOD_LCTRL;
+      break;
+    case MWKEY_RCTRL:
+      mask = MWKMOD_RCTRL;
+      break;
+    case MWKEY_LALT:
+      mask = MWKMOD_LALT;
+      break;
+    case MWKEY_RALT:
+      mask = MWKMOD_RALT;
+      break;
+    case MWKEY_LMETA:
+      mask = MWKMOD_LMETA;
+      break;
+    case MWKEY_RMETA:
+      mask = MWKMOD_RMETA;
+      break;
+    case MWKEY_NUMLOCK:
+      mask = MWKMOD_NUM;
+      break;
+    case MWKEY_CAPSLOCK:
+      mask = MWKMOD_CAPS;
+      break;
+    }
+
+  if (mask)
+    {
+      if (press)
+        {
+          *modifiers |= mask;
+        }
+      else
+        {
+          *modifiers &= ~mask;
+        }
+    }
+}
+
+#endif

--- a/src/drivers/kbd_nuttx_event.c
+++ b/src/drivers/kbd_nuttx_event.c
@@ -1,0 +1,100 @@
+#include <fcntl.h>
+#include <unistd.h>
+#include <nuttx/config.h>
+#include <nuttx/input/keyboard.h>
+#include "device.h"
+#include "kbd_nuttx_common.h"
+
+#ifndef NUTTX_KBD_EVENT_PATH
+#  define NUTTX_KBD_EVENT_PATH "/dev/kbd"
+#endif
+
+static int kbd_fd = -1;
+static MWKEYMOD modifiers = 0;
+
+static int nuttxkbd_Open(KBDDEVICE *pkd);
+static void nuttxkbd_Close(void);
+static void nuttxkbd_GetModifierInfo(MWKEYMOD *mods, MWKEYMOD *curmods);
+static int nuttxkbd_Read(MWKEY *kbuf, MWKEYMOD *mods, MWSCANCODE *scancode);
+
+KBDDEVICE kbddev =
+{
+  nuttxkbd_Open,
+  nuttxkbd_Close,
+  nuttxkbd_GetModifierInfo,
+  nuttxkbd_Read,
+  NULL
+};
+
+static int nuttxkbd_Open(KBDDEVICE *pkd)
+{
+  useconds_t delay = 1000;
+
+  if (kbd_fd >= 0)
+    {
+      close(kbd_fd);
+      kbd_fd = -1;
+    }
+
+  modifiers = 0;
+
+  while (delay <= 1024000)
+    {
+      kbd_fd = open(NUTTX_KBD_EVENT_PATH, O_RDONLY | O_NONBLOCK);
+      if (kbd_fd >= 0)
+        {
+          return DRIVER_OKFILEDESC(kbd_fd);
+        }
+      usleep(delay);
+      delay *= 2;
+    }
+
+  return DRIVER_FAIL;
+}
+
+static void nuttxkbd_Close(void)
+{
+  if (kbd_fd >= 0)
+    {
+      close(kbd_fd);
+      kbd_fd = -1;
+    }
+  modifiers = 0;
+}
+
+static void nuttxkbd_GetModifierInfo(MWKEYMOD *mods, MWKEYMOD *curmods)
+{
+  if (mods)
+    {
+      *mods = MWKMOD_SHIFT |
+              MWKMOD_CTRL | MWKMOD_ALT | MWKMOD_META |
+              MWKMOD_NUM | MWKMOD_CAPS;
+    }
+  if (curmods)
+    {
+      *curmods = modifiers;
+    }
+}
+
+static int nuttxkbd_Read(MWKEY *kbuf, MWKEYMOD *mods, MWSCANCODE *scancode)
+{
+  struct keyboard_event_s event;
+  int n;
+
+  n = read(kbd_fd, &event, sizeof(event));
+  if (n < (int)sizeof(event))
+    {
+      return KBD_NODATA;
+    }
+
+  MWKEY key = translate_keycode(event.code);
+  int press = (event.type == KEYBOARD_PRESS);
+
+  update_modifiers(&modifiers, key, press);
+
+  *kbuf = key;
+  *mods = modifiers;
+  *scancode = 0;
+
+  return press ? KBD_KEYPRESS : KBD_KEYRELEASE;
+}

--- a/src/drivers/kbd_nuttx_raw.c
+++ b/src/drivers/kbd_nuttx_raw.c
@@ -1,0 +1,208 @@
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <nuttx/config.h>
+#include <nuttx/streams.h>
+#include <nuttx/input/kbd_codec.h>
+#include "device.h"
+#include "kbd_nuttx_common.h"
+
+#ifndef NUTTX_KBD_RAW_PATH
+#  define NUTTX_KBD_RAW_PATH "/dev/kbda"
+#endif
+
+#define RAW_BUF_SIZE 64
+
+static int kbd_fd = -1;
+static MWKEYMOD modifiers = 0;
+
+static bool g_pending_release = false;
+static uint8_t g_last_raw_key = 0;
+
+static uint8_t raw_buf[RAW_BUF_SIZE];
+static int raw_buf_len = 0;
+static int raw_buf_pos = 0;
+static struct kbd_getstate_s g_kbd_state;
+
+static int nuttxkbd_Open(KBDDEVICE *pkd);
+static void nuttxkbd_Close(void);
+static void nuttxkbd_GetModifierInfo(MWKEYMOD *mods, MWKEYMOD *curmods);
+static int nuttxkbd_Read(MWKEY *kbuf, MWKEYMOD *mods, MWSCANCODE *scancode);
+
+KBDDEVICE kbddev =
+{
+  nuttxkbd_Open,
+  nuttxkbd_Close,
+  nuttxkbd_GetModifierInfo,
+  nuttxkbd_Read,
+  NULL
+};
+
+static MWKEY raw_byte_to_mwkey(uint8_t ch)
+{
+  switch (ch)
+    {
+    case 0x7f:
+      return MWKEY_BACKSPACE;
+    case 0x0a:
+      return MWKEY_ENTER;
+    default:
+      if (ch < 128)
+        {
+          return (MWKEY)ch;
+        }
+      return MWKEY_UNKNOWN;
+    }
+}
+
+static void raw_reset(void)
+{
+  raw_buf_len = 0;
+  raw_buf_pos = 0;
+  memset(&g_kbd_state, 0, sizeof(g_kbd_state));
+}
+
+static int nuttxkbd_Open(KBDDEVICE *pkd)
+{
+  useconds_t delay = 1000;
+
+  if (kbd_fd >= 0)
+    {
+      close(kbd_fd);
+      kbd_fd = -1;
+    }
+
+  modifiers = 0;
+  g_pending_release = false;
+  raw_reset();
+
+  while (delay <= 1024000)
+    {
+      kbd_fd = open(NUTTX_KBD_RAW_PATH, O_RDONLY | O_NONBLOCK);
+      if (kbd_fd >= 0)
+        {
+          return DRIVER_OKFILEDESC(kbd_fd);
+        }
+      usleep(delay);
+      delay *= 2;
+    }
+
+  return DRIVER_FAIL;
+}
+
+static void nuttxkbd_Close(void)
+{
+  if (kbd_fd >= 0)
+    {
+      close(kbd_fd);
+      kbd_fd = -1;
+    }
+  modifiers = 0;
+  g_pending_release = false;
+  raw_reset();
+}
+
+static void nuttxkbd_GetModifierInfo(MWKEYMOD *mods, MWKEYMOD *curmods)
+{
+  if (mods)
+    {
+      *mods = MWKMOD_SHIFT |
+              MWKMOD_CTRL | MWKMOD_ALT | MWKMOD_META |
+              MWKMOD_NUM | MWKMOD_CAPS;
+    }
+  if (curmods)
+    {
+      *curmods = modifiers;
+    }
+}
+
+static int nuttxkbd_Read(MWKEY *kbuf, MWKEYMOD *mods, MWSCANCODE *scancode)
+{
+  uint8_t ch;
+  int n;
+  int ret;
+  off_t nget_before;
+  struct lib_meminstream_s memstream;
+
+  if (g_pending_release)
+    {
+      g_pending_release = false;
+      *kbuf = (MWKEY)g_last_raw_key;
+      *mods = modifiers;
+      *scancode = 0;
+      return KBD_KEYRELEASE;
+    }
+
+  if (raw_buf_pos >= raw_buf_len)
+    {
+      n = read(kbd_fd, raw_buf, RAW_BUF_SIZE);
+      if (n <= 0)
+        {
+          return KBD_NODATA;
+        }
+
+      raw_buf_pos = 0;
+      raw_buf_len = n;
+    }
+
+  lib_meminstream(&memstream,
+                  (FAR const char *)(raw_buf + raw_buf_pos),
+                  raw_buf_len - raw_buf_pos);
+  nget_before = memstream.common.nget;
+
+  ret = kbd_decode((FAR struct lib_instream_s *)&memstream,
+                   &g_kbd_state, &ch);
+  raw_buf_pos += (int)(memstream.common.nget - nget_before);
+
+  switch (ret)
+    {
+    case KBD_ERROR:
+      raw_buf_pos = raw_buf_len;
+      return KBD_NODATA;
+
+    case KBD_PRESS:
+      {
+        MWKEY key = raw_byte_to_mwkey(ch);
+        if (key == MWKEY_UNKNOWN)
+          {
+            return KBD_NODATA;
+          }
+
+        g_pending_release = true;
+        g_last_raw_key = (uint8_t)key;
+
+        *kbuf = key;
+        *mods = modifiers;
+        *scancode = 0;
+        return KBD_KEYPRESS;
+      }
+
+    case KBD_RELEASE:
+      return KBD_NODATA;
+
+    case KBD_SPECPRESS:
+      {
+        MWKEY key = translate_keycode(ch);
+        update_modifiers(&modifiers, key, 1);
+
+        *kbuf = key;
+        *mods = modifiers;
+        *scancode = 0;
+        return KBD_KEYPRESS;
+      }
+
+    case KBD_SPECREL:
+      {
+        MWKEY key = translate_keycode(ch);
+        update_modifiers(&modifiers, key, 0);
+
+        *kbuf = key;
+        *mods = modifiers;
+        *scancode = 0;
+        return KBD_KEYRELEASE;
+      }
+
+    default:
+      return KBD_NODATA;
+    }
+}

--- a/src/drivers/mou_nuttx_mouse.c
+++ b/src/drivers/mou_nuttx_mouse.c
@@ -1,0 +1,98 @@
+#include <fcntl.h>
+#include <unistd.h>
+#include <nuttx/config.h>
+#include <nuttx/input/mouse.h>
+#include "device.h"
+
+#ifndef NUTTX_MOUSE_PATH
+#  define NUTTX_MOUSE_PATH "/dev/mouse0"
+#endif
+
+#define SCALE   3
+#define THRESH  5
+
+static int fd = -1;
+
+static int nuttxmouse_Open(MOUSEDEVICE *pmd);
+static void nuttxmouse_Close(void);
+static int nuttxmouse_GetButtonInfo(void);
+static void nuttxmouse_GetDefaultAccel(int *pscale, int *pthresh);
+static int nuttxmouse_Read(MWCOORD *dx, MWCOORD *dy, MWCOORD *dz, int *bp);
+
+MOUSEDEVICE mousedev =
+{
+  nuttxmouse_Open,
+  nuttxmouse_Close,
+  nuttxmouse_GetButtonInfo,
+  nuttxmouse_GetDefaultAccel,
+  nuttxmouse_Read,
+  NULL,
+  MOUSE_NORMAL
+};
+
+static int nuttxmouse_Open(MOUSEDEVICE *pmd)
+{
+  useconds_t delay = 1000;
+
+  while (delay <= 1024000)
+    {
+      fd = open(NUTTX_MOUSE_PATH, O_RDONLY | O_NONBLOCK);
+      if (fd >= 0)
+        {
+          return DRIVER_OKFILEDESC(fd);
+        }
+
+      usleep(delay);
+      delay *= 2;
+    }
+
+  return MOUSE_FAIL;
+}
+
+static void nuttxmouse_Close(void)
+{
+  if (fd >= 0)
+    {
+      close(fd);
+      fd = -1;
+    }
+}
+
+static int nuttxmouse_GetButtonInfo(void)
+{
+  return MWBUTTON_L | MWBUTTON_M | MWBUTTON_R |
+         MWBUTTON_SCROLLUP | MWBUTTON_SCROLLDN;
+}
+
+static void nuttxmouse_GetDefaultAccel(int *pscale, int *pthresh)
+{
+  *pscale = SCALE;
+  *pthresh = THRESH;
+}
+
+static int nuttxmouse_Read(MWCOORD *dx, MWCOORD *dy, MWCOORD *dz, int *bp)
+{
+  struct mouse_report_s report;
+  int n = read(fd, &report, sizeof(report));
+  if (n <= 0)
+    return MOUSE_NODATA;
+
+  *dx = report.x;
+  *dy = report.y;
+  *dz = report.wheel;
+
+  *bp = 0;
+  if (report.buttons & MOUSE_BUTTON_1)
+    *bp |= MWBUTTON_L;
+  if (report.buttons & MOUSE_BUTTON_2)
+    *bp |= MWBUTTON_R;
+  if (report.buttons & MOUSE_BUTTON_3)
+    *bp |= MWBUTTON_M;
+
+  if (report.wheel > 0)
+    *bp |= MWBUTTON_SCROLLUP;
+  if (report.wheel < 0)
+    *bp |= MWBUTTON_SCROLLDN;
+
+  return MOUSE_ABSPOS;
+}

--- a/src/drivers/mou_nuttx_ts.c
+++ b/src/drivers/mou_nuttx_ts.c
@@ -1,0 +1,95 @@
+#include <fcntl.h>
+#include <unistd.h>
+#include <nuttx/config.h>
+#include <nuttx/input/touchscreen.h>
+#include "device.h"
+
+#ifndef NUTTX_TOUCHSCREEN_PATH
+#  define NUTTX_TOUCHSCREEN_PATH "/dev/input0"
+#endif
+
+#define SCALE   3
+#define THRESH  5
+
+static int fd = -1;
+
+static int nuttxmouse_Open(MOUSEDEVICE *pmd);
+static void nuttxmouse_Close(void);
+static int nuttxmouse_GetButtonInfo(void);
+static void nuttxmouse_GetDefaultAccel(int *pscale, int *pthresh);
+static int nuttxmouse_Read(MWCOORD *dx, MWCOORD *dy, MWCOORD *dz, int *bp);
+
+MOUSEDEVICE mousedev =
+{
+  nuttxmouse_Open,
+  nuttxmouse_Close,
+  nuttxmouse_GetButtonInfo,
+  nuttxmouse_GetDefaultAccel,
+  nuttxmouse_Read,
+  NULL,
+  MOUSE_NORMAL
+};
+
+static int nuttxmouse_Open(MOUSEDEVICE *pmd)
+{
+  useconds_t delay = 1000;
+
+  while (delay <= 1024000)
+    {
+      fd = open(NUTTX_TOUCHSCREEN_PATH, O_RDONLY | O_NONBLOCK);
+      if (fd >= 0)
+        {
+          return DRIVER_OKFILEDESC(fd);
+        }
+
+      usleep(delay);
+      delay *= 2;
+    }
+
+  return MOUSE_FAIL;
+}
+
+static void nuttxmouse_Close(void)
+{
+  if (fd >= 0)
+    {
+      close(fd);
+      fd = -1;
+    }
+}
+
+static int nuttxmouse_GetButtonInfo(void)
+{
+  return MWBUTTON_L;
+}
+
+static void nuttxmouse_GetDefaultAccel(int *pscale, int *pthresh)
+{
+  *pscale = SCALE;
+  *pthresh = THRESH;
+}
+
+static int nuttxmouse_Read(MWCOORD *dx, MWCOORD *dy, MWCOORD *dz, int *bp)
+{
+  struct touch_sample_s sample;
+  int n = read(fd, &sample, sizeof(sample));
+  if (n <= 0)
+    return MOUSE_NODATA;
+
+  *dz = 0;
+
+  uint8_t flags = sample.point[0].flags;
+  *bp = (flags & (TOUCH_DOWN | TOUCH_MOVE)) ? MWBUTTON_L : 0;
+
+  /* Single-touch: only sample.point[0] is used.
+   * For multi-touch support, iterate npoints and report each contact. */
+
+  if (flags & TOUCH_POS_VALID)
+    {
+      *dx = sample.point[0].x;
+      *dy = sample.point[0].y;
+      return MOUSE_ABSPOS;
+    }
+
+  return MOUSE_NOMOVE;
+}

--- a/src/drivers/scr_nuttx.c
+++ b/src/drivers/scr_nuttx.c
@@ -1,0 +1,109 @@
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <nuttx/video/fb.h>
+#include "device.h"
+#include "genfont.h"
+#include "genmem.h"
+#include "fb.h"
+
+#ifndef NUTTX_FB_PATH
+#  define NUTTX_FB_PATH "/dev/fb0"
+#endif
+
+static int fb = -1;
+
+static PSD fb_open(PSD psd);
+static void fb_close(PSD psd);
+
+SCREENDEVICE scrdev = {
+  0, 0, 0, 0, 0, 0, 0, NULL, 0, NULL, 0, 0, 0, 0, 0, 0,
+  gen_fonts,
+  fb_open,
+  fb_close,
+  NULL,
+  gen_getscreeninfo,
+  gen_allocatememgc,
+  gen_mapmemgc,
+  gen_freememgc,
+  gen_setportrait,
+  NULL,
+  NULL
+};
+
+static PSD fb_open(PSD psd)
+{
+  struct fb_videoinfo_s vinfo;
+  struct fb_planeinfo_s pinfo;
+  PSUBDRIVER subdriver;
+
+  fb = open(NUTTX_FB_PATH, O_RDWR);
+  if (fb < 0)
+    {
+      EPRINTF("Error: cannot open %s. Check CONFIG_VIDEO_FB\n",
+              NUTTX_FB_PATH);
+      return NULL;
+    }
+
+  if (ioctl(fb, FBIOGET_VIDEOINFO, &vinfo) < 0 ||
+      ioctl(fb, FBIOGET_PLANEINFO, &pinfo) < 0)
+    {
+      EPRINTF("Error: cannot read framebuffer info\n");
+      goto fail;
+    }
+
+  if (vinfo.xres == 0 || vinfo.yres == 0)
+    {
+      EPRINTF("Error: zero resolution\n");
+      goto fail;
+    }
+
+  psd->xres = psd->xvirtres = vinfo.xres;
+  psd->yres = psd->yvirtres = vinfo.yres;
+  psd->bpp = pinfo.bpp;
+  psd->planes = 1;
+  psd->pitch = pinfo.stride;
+  psd->size = pinfo.fblen;
+  psd->ncolors = (psd->bpp >= 24) ? (1 << 24) : (1 << psd->bpp);
+  psd->flags = PSF_SCREEN | PSF_ADDRMMAP;
+  psd->portrait = MWPORTRAIT_NONE;
+
+  psd->pixtype = SCREEN_PIXTYPE;
+  psd->data_format = set_data_format(psd);
+
+  psd->addr = mmap(NULL, psd->size, PROT_READ | PROT_WRITE, MAP_SHARED, fb, 0);
+  if (psd->addr == MAP_FAILED)
+    {
+      EPRINTF("Error: mmap failed\n");
+      goto fail;
+    }
+
+  subdriver = select_fb_subdriver(psd);
+  if (!subdriver)
+    {
+      EPRINTF("Error: no subdriver for %dbpp\n", psd->bpp);
+      goto fail;
+    }
+  set_subdriver(psd, subdriver);
+
+  return psd;
+
+fail:
+  if (fb >= 0)
+    {
+      close(fb);
+      fb = -1;
+    }
+  return NULL;
+}
+
+static void fb_close(PSD psd)
+{
+  if (fb >= 0)
+    {
+      munmap(psd->addr, psd->size);
+      close(fb);
+      fb = -1;
+    }
+}

--- a/src/include/mwconfig.nuttx
+++ b/src/include/mwconfig.nuttx
@@ -1,0 +1,30 @@
+/* mwconfig.nuttx - NuttX port-specific Microwindows configuration file
+ * Included by mwconfig.h via -DMWCONFIG_FILE='"mwconfig.nuttx"'
+ */
+
+#define NANOWM              1
+#define USE_ALLOCA          1
+#define UNIX                1
+#define HAVE_MMAP           1
+#define HAVE_SIGNAL         1
+#define HAVE_SELECT         1
+#define HAVE_FILEIO         1
+#define HAVE_FNT_SUPPORT    1
+#define MW_FEATURE_TIMERS   1
+#define MW_FEATURE_BITMAPS  1
+#define MW_FEATURE_IMAGES   1
+#define MW_FEATURE_SHAPES   1
+#define MW_FEATURE_PORTRAIT 1
+#define MW_FEATURE_PALETTE  1
+#define MW_FEATURE_TINY     0
+#define NUKLEARUI           1
+#define SCREEN_PIXTYPE      MWPF_TRUECOLORARGB
+#define SCREEN_DEPTH        8
+#define OUTLINE_MOVE        1
+#define NO_AUTO_MOVE        1
+#define TRANSLATE_ESCAPE_SEQUENCES 0
+#define UPDATEREGIONS       1
+#define ERASEMOVE           1
+#define NOCLIPPING          0
+#define POLYREGIONS         1
+#define DYNAMICREGIONS      1


### PR DESCRIPTION
Introduce scr_nuttx.c using the NuttX framebuffer API, keyboard drivers for event-mode (kbd_nuttx_event.c) and raw byte-stream (kbd_nuttx_raw.c), and pointing drivers for mouse (mou_nuttx_mouse.c) and touchscreen (mou_nuttx_ts.c).  Each driver accepts a device path override.

Add mwconfig.nuttx with NuttX-appropriate defaults, included via the MWCONFIG_FILE mechanism.  Add NuttX ARCH/KEYBOARD/MOUSE entries to Objects.rules so the correct drivers are linked when building for NuttX.