### PR TITLE
Target operating system defines are check for presence to prevent war…

### DIFF
--- a/src/contrib/doom/doomtype.h
+++ b/src/contrib/doom/doomtype.h
@@ -45,7 +45,7 @@ typedef unsigned char byte;
 
 
 // Predefined with some OS.
-#ifdef LINUX
+#if defined(LINUX) && LINUX
 #include <values.h>
 #else
 #ifndef MAXCHAR

--- a/src/contrib/nanox-test/nterm.c
+++ b/src/contrib/nanox-test/nterm.c
@@ -5,8 +5,12 @@
  * Greg Haerr
  */
 
-#if LINUX | MACOSX
+#if defined(LINUX) && LINUX
 #define UNIX98	1		/* use new-style /dev/ptmx, /dev/pts/0*/
+#elif defined(MACOSX) && MACOSX
+#define UNIX98	1		/* use new-style /dev/ptmx, /dev/pts/0*/
+#elif !defined(UNIX98)
+#define UNIX98  0
 #endif
 #define _XOPEN_SOURCE 600
 #include <stdio.h>
@@ -160,7 +164,7 @@ HandleEvent(GR_EVENT *ep)
 	}
 }
 
-#if ELKS
+#if defined(ELKS) && ELKS
 char * nargv[2] = {"/bin/sash", NULL};
 #else
 #if DOS_DJGPP

--- a/src/contrib/nanox-test/select.c
+++ b/src/contrib/nanox-test/select.c
@@ -15,7 +15,7 @@
 #include <unistd.h>
 #include <sys/time.h>
 #endif
-#if ELKS
+#if defined(ELKS) && ELKS
 #include <linuxmt/posix_types.h>
 #include <linuxmt/time.h>
 #endif
@@ -53,7 +53,7 @@ GsTerminate(void)
 	exit(0);
 }
 
-#if MSDOS
+#if defined(MSDOS) && MSDOS
 void
 GsSelect(void)
 {

--- a/src/contrib/vnc/srvmain.c
+++ b/src/contrib/vnc/srvmain.c
@@ -13,7 +13,7 @@
 #include "uni_std.h"
 #include "sys_time.h"
 
-#if RTEMS
+#if defined(RTEMS) && RTEMS
 #include <rtems/mw_uid.h>
 #endif
 
@@ -262,7 +262,7 @@ GrOpen(void)
 	}
 	SERVER_UNLOCK();
 
-#if MSDOS
+#if defined(MSDOS) && MSDOS
 	atexit(GsTerminate);
 #endif
 #endif /* NONETWORK*/
@@ -650,7 +650,7 @@ again:
 }
 
 /********************************************************************************/
-#elif RTEMS
+#elif defined(RTEMS) && RTEMS
 extern struct MW_UID_MESSAGE m_kbd;
 extern struct MW_UID_MESSAGE m_mou;
 

--- a/src/contrib/winextra/extra_windef.h
+++ b/src/contrib/winextra/extra_windef.h
@@ -19,7 +19,7 @@ typedef unsigned int UINT32, *PUINT32;
 //typedef uint32_t DWORD_PTR, UINT_PTR, *PUINT_PTR;
 #endif
 
-#if _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER
 typedef __int64 LONG64, *PLONG64;
 typedef __int64 INT64, *PINT64;
 typedef unsigned __int64 ULONG64, *PULONG64;
@@ -33,7 +33,7 @@ typedef unsigned long long DWORD64, *PDWORD64;
 typedef unsigned long long UINT64, *PUINT64;
 #endif
 
-#if _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER
 typedef __int64 LONGLONG;
 typedef unsigned __int64 ULONGLONG;
 #else

--- a/src/contrib/winextra/winbase.h
+++ b/src/contrib/winextra/winbase.h
@@ -90,7 +90,7 @@ typedef struct {
 } BITMAPV5HEADER, *LPBITMAPV5HEADER, *PBITMAPV5HEADER;
 
 
-#if _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER
 typedef __int64 LONGLONG;
 typedef unsigned __int64 ULONGLONG;
 #else

--- a/src/demos/mwin/mwdemo.c
+++ b/src/demos/mwin/mwdemo.c
@@ -36,7 +36,7 @@ unsigned _stklen = 4096;
 /* not used*/
 #define CLIENT3D	0	/* old client draw test*/
 
-#if RTEMS
+#if defined(RTEMS) && RTEMS
 #undef GRAPH3D
 #undef CONTROLS
 #define CONTROLS	1	/* win32 controls demo*/
@@ -59,7 +59,9 @@ extern MWIMAGEHDR image_cs1;
 extern MWIMAGEHDR image_rle8;
 
 #if CONTROLS
-#if ELKS | MSDOS
+#if defined(ELKS) && ELKS
+PMWIMAGEHDR image = &image_cs1;		/* 2 color bitmap for 16 color systems*/
+#elif defined(MSDOS) && MSDOS
 PMWIMAGEHDR image = &image_cs1;		/* 2 color bitmap for 16 color systems*/
 #else
 PMWIMAGEHDR image = &image_penguin;

--- a/src/demos/mwin/mwmine.c
+++ b/src/demos/mwin/mwmine.c
@@ -988,7 +988,7 @@ LRESULT TestMyWinProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                         bom[ran1][ran2].flag = 1;
 			i++;
                      } 
-#if RTEMS
+#if defined(RTEMS) && RTEMS
 		      else i++;		/* bad rtems random function*/
 #endif
                 }

--- a/src/demos/mwin/mwterm.c
+++ b/src/demos/mwin/mwterm.c
@@ -29,7 +29,7 @@
 /*#define FONTNAME	OEM_FIXED_FONT*/
 #define APPCLASS	"mterm"
 
-#if ELKS
+#if defined(ELKS) && ELKS
 #define SHELL	"/bin/sash"
 #elif DOS_DJGPP
 #define SHELL	"bash"
@@ -252,7 +252,7 @@ ptysignaled(int signo)
 {
 	switch(signo) {
 	case SIGINT:	/* interrupt*/
-#if !ELKS
+#if !defined(ELKS) || !ELKS
 		/* this doesn't work, can anyone fix it?*/
 		killpg(pid, SIGINT);
 #endif

--- a/src/demos/nanox/nxcalc.c
+++ b/src/demos/nanox/nxcalc.c
@@ -11,7 +11,7 @@
 #include <ctype.h>
 #include <math.h>
 #include "nano-X.h"
-#if ELKS
+#if defined(ELKS) && ELKS
 #include <sys/linksym.h>
 #endif
 
@@ -55,7 +55,7 @@ static double display_to_double(void) {
 }
 
 static void set_display_from_double(double v) {
-#if ELKS
+#if defined(ELKS) && ELKS
     __LINK_SYMBOL(dtostr);
 #endif
     char buf[128];

--- a/src/demos/nanox/nxmine.c
+++ b/src/demos/nanox/nxmine.c
@@ -27,7 +27,7 @@
 
 #define FULLSIZE	(MAXSIZE + 2)	/* board size including borders */
 
-#if __ECOS
+#if defined(__ECOS) && __ECOS
 /* 240x320 screen values*/
 #define	BOARDGAP	2		/* millimeter gap around board */
 #define	RIGHTGAP	2		/* mm gap between board, right side */
@@ -825,7 +825,7 @@ delay(void)
 {
 	GR_COUNT	i;
 
-#if ELKS
+#if defined(ELKS) && ELKS
 	i = 32000;
 	do {
 		GrFlush();

--- a/src/demos/nanox/nxstart.c
+++ b/src/demos/nanox/nxstart.c
@@ -56,7 +56,7 @@ static void do_buttonup(GR_EVENT_BUTTON *ep);
 static void do_update(GR_EVENT_UPDATE *ep);
 static void do_mouse(GR_EVENT_MOUSE *ep);
 
-#if ELKS
+#if defined(ELKS) && ELKS
 #define PATH    "/bin/"
 #else
 #define PATH    "bin/"
@@ -71,7 +71,7 @@ struct app_info {
 	{"tetris",  PATH "nxtetris"},
 	{"world",   PATH "nxworld"},
 	{"landmine",PATH "nxmine"},
-#if ELKS
+#if defined(ELKS) && ELKS
 	{"calculator",PATH "nxcalc"},
 #else
 	{"aafont",    PATH "demo-aafont"},

--- a/src/demos/nanox/nxterm.c
+++ b/src/demos/nanox/nxterm.c
@@ -68,7 +68,7 @@
 #include <termios.h>
 #endif
 
-#if ELKS
+#if defined(ELKS) && ELKS
 #define stdcol          80
 #define stdrow          25
 #define	KBDBUF          1024
@@ -950,7 +950,7 @@ scrolltop, scrollbottom = upper and lower scroll region limit in lines/rows
 		break;
 
     case 'n':/* DSR device status report */
-#if ELKS
+#if defined(ELKS) && ELKS
 		strcpy(buf, "\033[");
 		strcat(buf, itoa(cury+1));
 		strcat(buf, ";");
@@ -1774,7 +1774,7 @@ char * nargv[2] = {"bash", NULL};
 char * nargv[2] = {"/bin/sh", NULL};
 #endif
 
-#if ELKS
+#if defined(ELKS) && ELKS
 int term_init(void)
 {
 	int tfd;

--- a/src/demos/nanox/nxterm.h
+++ b/src/demos/nanox/nxterm.h
@@ -7,7 +7,15 @@
  *	++eero
  */
 
-#if LINUX | MACOSX
+#if defined(LINUX) && LINUX
+#define USE_NGTERM 1
+#elif defined(MACOSX) && MACOSX
+#define USE_NGTERM 1
+#else
+#define USE_NGTERM 0
+#endif
+
+#if USE_NGTERM
 static char termtype_string[] = "TERM=ngterm";
 static char termcap_string[1024] =
 "TERMCAP=ngterm|nano-X vt52 terminal:\

--- a/src/demos/nanox/nxtetris.c
+++ b/src/demos/nanox/nxtetris.c
@@ -86,7 +86,7 @@
 #include "nxcolors.h"
 #include "nxtetris.h"
 
-#if ELKS
+#if defined(ELKS) && ELKS
 #define srandom     srand
 #define random      rand
 #endif

--- a/src/demos/nanox/nxtetris.h
+++ b/src/demos/nanox/nxtetris.h
@@ -38,7 +38,7 @@
  * array of shape descriptions (you can add your own new shapes quite easily).
  */
 
-#ifndef __ECOS
+#if !defined(__ECOS) || !__ECOS
 //#define USE_HISCORE_FILE
 #define HISCORE_FILE "/usr/games/nanotetris.hiscore"
 #endif
@@ -58,7 +58,7 @@
 extern int WELL_HEIGHT, WELL_VISIBLE_HEIGHT;
 #define WELL_NOTVISIBLE (WELL_HEIGHT - WELL_VISIBLE_HEIGHT)
 #define LEVEL_DIVISOR 500
-#ifdef __ECOS
+#if defined(__ECOS) && __ECOS
 #define DROP_BLOCK_DELAY 10
 #else
 #define DROP_BLOCK_DELAY 25

--- a/src/demos/nanox/nxworld.c
+++ b/src/demos/nanox/nxworld.c
@@ -14,7 +14,7 @@
 
 #define MAPW    400
 #define MAPH    240
-#if ELKS
+#if defined(ELKS) && ELKS
 #define	MAPFILE	"/lib/nxworld.map"
 #else
 #define	MAPFILE	"images/demos/nanox/nxworld.map"
@@ -167,7 +167,7 @@ main(int argc, char **argv)
 
 	GrGetScreenInfo(&si);
 
-#if __ECOS	/* 240x320 screen*/
+#if defined(__ECOS) && __ECOS	/* 240x320 screen*/
 	COLS = si.cols - 10;
 	ROWS = si.rows - 40;
 #endif

--- a/src/demos/nxscribble/li_recognizer.c
+++ b/src/demos/nxscribble/li_recognizer.c
@@ -53,7 +53,7 @@ static char *lialg_recognize_stroke(rClassifier *, point_list *);
 char* li_err_msg = NULL;
 char _zdebug_flag[128];
 
-#if __ECOS
+#if defined(__ECOS) && __ECOS
 #define BCOPY		bcopy
 #else
 /* This is standard - defined in <stdlib.h> */

--- a/src/demos/nxscribble/util.h
+++ b/src/demos/nxscribble/util.h
@@ -61,7 +61,7 @@ int			GdError(const char *format, ...);
 
 /* various BSD to lattice C name changes */
 
-#ifdef __ECOS
+#if defined(__ECOS) && __ECOS
 extern char *strdup(char *);
 #endif
 #define index	strchr

--- a/src/demos/tuxchess/main.c
+++ b/src/demos/tuxchess/main.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <signal.h>
-#if RTEMS
+#if defined(RTEMS) && RTEMS
 #include <time.h>
 #else
 #include <sys/time.h>
@@ -138,7 +138,7 @@ BOOL ftime_ok = FALSE;  /* does ftime return milliseconds? */
 */
 int get_ms(void)
 {
-#if RTEMS
+#if defined(RTEMS) && RTEMS
 	struct timespec tp;
 
 	clock_gettime( CLOCK_REALTIME, &tp );

--- a/src/drivers/deprecated/kbd_ipaq.c
+++ b/src/drivers/deprecated/kbd_ipaq.c
@@ -23,7 +23,7 @@
 #define IPAQ_SCANCODE_ACTION   138
 #define IPAQ_SCANCODE_SUSPEND  139
 
-#if __ECOS
+#if defined(__ECOS) && __ECOS
 #define KEYBOARD "/dev/kbd"
 #else
 #define KEYBOARD "/dev/h3600_key"

--- a/src/drivers/deprecated/mou_ipaq.c
+++ b/src/drivers/deprecated/mou_ipaq.c
@@ -16,7 +16,7 @@
 #include <sys/ioctl.h>
 #include "device.h"
 
-#ifdef __ECOS
+#if defined(__ECOS) && __ECOS
 #define TOUCHDEVICE	"/dev/ts"			/* iPAQ*/
 #else
 #define TOUCHDEVICE	"/dev/h3600_tsraw"		/* iPAQ*/

--- a/src/drivers/deprecated/mwlirc.c
+++ b/src/drivers/deprecated/mwlirc.c
@@ -53,7 +53,7 @@ static int mwlirc_buf_line_len = 0;
 
 static int mwlirc_packet_state = MWLIRC_EXPECT_BEGIN;
 
-#if TRIMEDIA
+#if defined(TRIMEDIA) && TRIMEDIA
 static char * my_strchr(char * buf, char ch)
 {
 	while ((*buf != '\0') & (*buf != ch)) buf++;

--- a/src/drivers/deprecated/scr_allegro.c
+++ b/src/drivers/deprecated/scr_allegro.c
@@ -105,7 +105,7 @@ allegro_open(PSD psd)
     set_close_button_callback(close_button_proc);
 	set_color_depth(avbpp);
 	
-#if __MINGW32__ 
+#if defined(__MINGW32__) && __MINGW32__
     set_gfx_mode(GFX_GDI,1024,768,0,0); //GDI for Windows
 #else
 	set_gfx_mode(GFX_XWINDOWS,640,480,0,0);

--- a/src/drivers/deprecated/scr_fb.c
+++ b/src/drivers/deprecated/scr_fb.c
@@ -12,7 +12,7 @@
 #include <assert.h>
 #include <fcntl.h>
 #include <limits.h>
-#if LINUX
+#if defined(LINUX) && LINUX
 #include <linux/fb.h>
 #include <linux/kd.h>
 #include <linux/vt.h>
@@ -62,7 +62,7 @@ SCREENDEVICE	scrdev = {
 	NULL				/* PreSelect*/
 };
 
-#if !LINUX
+#if !defined(LINUX) || !LINUX
 /* Allow compilation on non-linux systems. For bin/fbe use, set FRAMEBUFFER=/tmp/fb0 in environment*/
 /* Defines linux structures to set framebuffer defaults without ioctl*/
 /* FIXME nanox/clientfb.c direct framebuffer needs access to this*/
@@ -206,7 +206,7 @@ fb_open(PSD psd)
 	visual = fb_fix.visual;
 
 	psd->portrait = MWPORTRAIT_NONE;
-#if LINUX_SPARC
+#if defined(LINUX_SPARC) && LINUX_SPARC
 	psd->xres = psd->xvirtres = fb_var.xres_virtual;
 	psd->yres = psd->yvirtres = fb_var.yres_virtual;
 #else
@@ -297,7 +297,7 @@ fb_open(PSD psd)
 	/* mmap framebuffer into this address space*/
 	psd->size = (psd->size + getpagesize() - 1) / getpagesize() * getpagesize();
 
-#if LINUX_SPARC
+#if defined(LINUX_SPARC) && LINUX_SPARC
 #define CG3_MMAP_OFFSET 0x4000000
 #define CG6_RAM    		0x70016000
 #define TCX_RAM8BIT		0x00000000

--- a/src/drivers/deprecated/scr_herc.c
+++ b/src/drivers/deprecated/scr_herc.c
@@ -14,7 +14,7 @@
  *	The environment variable CHARHEIGHT if set will set the assumed rom
  *	font character height, which defaults to 14.
  */
-#if ELKS
+#if defined(ELKS) && ELKS
 #include <linuxmt/ntty.h>
 #endif
 #include <stdio.h>
@@ -71,7 +71,7 @@ HERC_open(PSD psd)
 	if(ioperm(0x3b4, 0x0d, 1))
 		return NULL;
 #endif
-#if ELKS
+#if defined(ELKS) && ELKS
 	/* disallow console switching while in graphics mode*/
 	if(ioctl(0, DCGET_GRAPH) != 0)
 		return NULL;
@@ -117,7 +117,7 @@ HERC_close(PSD psd)
 		0x61,0x50,0x52,0x0f,0x19,6,0x19,0x19,2,0x0d,0x0b,0x0c
 	};
 
-#if ELKS
+#if defined(ELKS) && ELKS
 	/* allow console switching again*/
 	ioctl(0, DCREL_GRAPH);
 #endif

--- a/src/drivers/deprecated/scr_prsm.c
+++ b/src/drivers/deprecated/scr_prsm.c
@@ -24,7 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "device.h"
-#ifdef _MINIX
+#if defined(_MINIX) && _MINIX
 #include <sys/types.h>
 #endif
 #include "genfont.h"

--- a/src/drivers/deprecated/vgainit.c
+++ b/src/drivers/deprecated/vgainit.c
@@ -7,7 +7,7 @@
 #include "device.h"
 #include "vgaplan4.h"
 
-#if RTEMS
+#if defined(RTEMS) && RTEMS
 #define ROMFONT		0	/* =0 no bios rom fonts available*/
 #else
 #define ROMFONT		1	/* =1 uses PC rom fonts */

--- a/src/drivers/fb.c
+++ b/src/drivers/fb.c
@@ -109,7 +109,7 @@ select_fb_subdriver(PSD psd)
 	extern PSUBDRIVER memplan4[4];
 #endif
 
-#if ELKS
+#if defined(ELKS) && ELKS
 	pdriver = memplan4;
 #elif SWIEROS
 	pdriver = fblinear32rgba;

--- a/src/drivers/fb.c
+++ b/src/drivers/fb.c
@@ -107,7 +107,7 @@ select_fb_subdriver(PSD psd)
 	extern PSUBDRIVER fblinear32rgba[4];
 	extern PSUBDRIVER memplan4[4];
 
-#if ELKS
+#if defined(ELKS) && ELKS
 	pdriver = memplan4;
 #elif SWIEROS
 	pdriver = fblinear32rgba;

--- a/src/drivers/kbd_rtems.c
+++ b/src/drivers/kbd_rtems.c
@@ -67,7 +67,7 @@ MWKbd_Open (KBDDEVICE *pkd)
 {
         int rc;
 	m_kbd.type = MV_UID_INVALID;
-#if RTEMS
+#if defined(RTEMS) && RTEMS
 	kbd_fd = fileno (stdin);
 #endif
 	rc = uid_open_queue (Q_NAME, O_CREAT | O_RDWR, Q_MAX_MSGS);
@@ -83,7 +83,7 @@ MWKbd_Close (void)
 {
         uid_unregister_device (kbd_fd);
 	uid_close_queue ();
-#if RTEMS
+#if defined(RTEMS) && RTEMS
 	close (kbd_fd);
 #endif
 }
@@ -116,7 +116,7 @@ MWKbd_Read (MWKEY *buf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 		*modifiers = 0;
 		/* consume event */
 		m_kbd.type = MV_UID_INVALID;
-#if __ECOS
+#if defined(__ECOS) && __ECOS
                 if (m_kbd.m.kbd.mode==2)
                    return 2;
                 else

--- a/src/drivers/kbd_tty.c
+++ b/src/drivers/kbd_tty.c
@@ -17,9 +17,9 @@
 
 #define DEBUG_ESCAPE_SEQUENCES	0
 
-#if LINUX_POWERPPC
+#if defined(LINUX_POWERPPC) && LINUX_POWERPPC
 #   define KEYBOARD	"/dev/tty0"	/* keyboard associated with screen Foedrowitz 2006mar15 */
-#elif ELKS
+#elif defined(ELKS) && ELKS
 #   define KEYBOARD	"/dev/tty1"	/* keyboard associated with screen*/
 #else
 #   define KEYBOARD	"/dev/tty"	/* keyboard associated with screen*/
@@ -33,7 +33,7 @@ static int  TTY_Open(KBDDEVICE *pkd);
 static void TTY_Close(void);
 static void TTY_GetModifierInfo(MWKEYMOD *modifiers, MWKEYMOD *curmodifiers);
 static int  TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode);
-#if _MINIX
+#if defined(_MINIX) && _MINIX
 static int  TTY_Poll(void) { return 1; }
 #endif
 
@@ -42,7 +42,7 @@ KBDDEVICE kbddev = {
 	TTY_Close,
 	TTY_GetModifierInfo,
 	TTY_Read,
-#if _MINIX
+#if defined(_MINIX) && _MINIX
 	TTY_Poll
 #else
 	NULL
@@ -156,7 +156,7 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 	}
 	
 	mwkey = buf[0];
-#if ELKS
+#if defined(ELKS) && ELKS
 	if(mwkey == 01)         /* exit on ^A */
 		return KBD_QUIT;
 #elif __fiwix__
@@ -171,7 +171,7 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 			/* Need more characters - escape sequences are 3+ chars */
 			do {
 				cc = read(fd, buf + buflen, 3 - buflen);
-#if ELKS
+#if defined(ELKS) && ELKS
 				if (cc == 0 && buflen == 1) {   /* allow lone ESC -> ESC */
 					buflen = 0;
 					mwkey = 27;
@@ -190,7 +190,7 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 		}
 
 		switch (buf[1]) {
-#if !ELKS
+#if !defined(ELKS) || !ELKS
 		case 'O': /* Letter O */
 			switch (buf[2]) {
 			case 'P': mwkey = MWKEY_F1; break;
@@ -234,7 +234,7 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 #endif
 		case '[':
 			switch (buf[2]) {
-#if !ELKS
+#if !defined(ELKS) || !ELKS
 			case '1':
 				if (buflen < 4)
 					return 0;
@@ -293,7 +293,7 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 			case 'D': mwkey = MWKEY_LEFT;  break;
 			case 'F': mwkey = MWKEY_END;   break;
 			case 'H': mwkey = MWKEY_HOME;  break;
-#if !ELKS
+#if !defined(ELKS) || !ELKS
 			case '[':
 				if (buflen < 4)
 					return 0;
@@ -322,7 +322,7 @@ TTY_Read(MWKEY *kbuf, MWKEYMOD *modifiers, MWSCANCODE *scancode)
 			break;
 		}
 		if (mwkey == 0) {
-#if !ELKS
+#if !defined(ELKS) || !ELKS
 			if (buflen >= 5) {
 				EPRINTF("WARNING: Unknown escape sequence ESC '%c' '%c' '%c' '%c'.\n"
 					"(If you're trying to type a real escape, you have to press it 3 times.)\n",

--- a/src/drivers/mou_rtems.c
+++ b/src/drivers/mou_rtems.c
@@ -75,7 +75,7 @@ MWMou_Open (MOUSEDEVICE *pmd)
         int rc;
 	m_mou.type = MV_UID_INVALID;
 	rc = uid_open_queue (Q_NAME, O_CREAT | O_RDWR, Q_MAX_MSGS);
-#if RTEMS
+#if defined(RTEMS) && RTEMS
 	mou_fd = open (MOUSE_DEVICE, O_NONBLOCK);
 #endif
 	uid_register_device (mou_fd, Q_NAME);
@@ -90,7 +90,7 @@ MWMou_Close (void)
 {
         uid_unregister_device (mou_fd);
         uid_close_queue ();
-#if RTEMS
+#if defined(RTEMS) && RTEMS
 	close (mou_fd);
 #endif
 }

--- a/src/drivers/mou_ser.c
+++ b/src/drivers/mou_ser.c
@@ -38,11 +38,11 @@
 #endif
 
 /* default settings*/
-#if ELKS
+#if defined(ELKS) && ELKS
 #define	MOUSE_PORT	"/dev/ttyS0"	/* default port unless MOUSE_PORT= environ var */
 #define	MOUSE_QEMU	"/dev/ttyS1"	/* default port on QEMU */
 #define MOUSE_TYPE	"ms"            /* microsoft mouse */
-#elif _MINIX
+#elif defined(_MINIX) && _MINIX
 #define	MOUSE_PORT	"/dev/mouse"
 #define	MOUSE_QEMU	"/dev/ttyS1"
 #define	MOUSE_TYPE	"ms"
@@ -122,7 +122,7 @@ static int  	MOU_Read(MWCOORD *dx, MWCOORD *dy, MWCOORD *dz, int *bptr);
 static int  	ParsePC(int);		/* routine to interpret PC mouse */
 static int  	ParseMS(int);		/* routine to interpret MS mouse */
 static int  	ParsePS2(int);		/* routine to interpret PS/2 mouse */
-#if _MINIX
+#if defined(_MINIX) && _MINIX
 static int	MOU_Poll(void) { return 1; }
 #endif
 
@@ -132,7 +132,7 @@ MOUSEDEVICE mousedev = {
 	MOU_GetButtonInfo,
 	MOU_GetDefaultAccel,
 	MOU_Read,
-#if _MINIX
+#if defined(_MINIX) && _MINIX
 	MOU_Poll,
 #else
 	NULL,
@@ -191,7 +191,7 @@ MOU_Open(MOUSEDEVICE *pmd)
 		return -2;		/* no mouse */
 	}
 
-#if ELKS
+#if defined(ELKS) && ELKS
 	EPRINTF("Opening mouse on %s\n", port);
 	mouse_fd = open(port, O_RDONLY | O_EXCL | O_NOCTTY | O_NONBLOCK);
 #else
@@ -229,12 +229,12 @@ MOU_Open(MOUSEDEVICE *pmd)
 
 	if(cfgetispeed(&termios) != B1200)
 		cfsetispeed(&termios, B1200);
-#if _MINIX
+#if defined(_MINIX) && _MINIX
 	if(cfgetospeed(&termios) != B1200)
 		cfsetospeed(&termios, B1200);
 #endif
 
-#if !_MINIX
+#if !defined(_MINIX) || !_MINIX
 	termios.c_cflag &= ~CBAUD;
 	termios.c_cflag |= B1200;
 #endif
@@ -317,7 +317,7 @@ MOU_Read(MWCOORD *dx, MWCOORD *dy, MWCOORD *dz, int *bptr)
 		if (nbytes < 0) {
 			if (errno == EINTR || errno == EAGAIN)
 				return MOUSE_NODATA;
-#if _MINIX
+#if defined(_MINIX) && _MINIX
 			return MOUSE_NODATA;
 #else
 			return MOUSE_FAIL;

--- a/src/drivers/osdep.c
+++ b/src/drivers/osdep.c
@@ -9,17 +9,17 @@
 #include <string.h>
 #include <fcntl.h>
 
-#if __ECOS
+#if defined(__ECOS) && __ECOS
 #include <cyg/infra/diag.h>
 #elif ANDROID
 #include <android/log.h>
 #elif EMSCRIPTEN
 #include <emscripten.h>
-#elif PSP
+#elif defined(PSP) && PSP
 #include <pspkernel.h>
 #include <psputils.h>
 #include <pspdebug.h>
-#elif _MSC_VER
+#elif defined(_MSC_VER) && _MSC_VER
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>		/* pull in REAL windows.h for _MSC_VER, no -Isrc/include*/
 #endif
@@ -38,7 +38,7 @@ extern	uint32_t ajag_mstimer;
 #endif
 
 
-#if !ELKS
+#if !defined(ELKS) || !ELKS
 /**
  * Output error message
  */
@@ -49,22 +49,22 @@ GdError(const char *format, ...)
 	char 	buf[128];
 
 	va_start(args, format);
-#if __ECOS
+#if defined(__ECOS) && __ECOS
 	/* diag_printf() has much less dependencies than write() */
 	diag_printf(format, args);
 #elif AJAGUAR
 #pragma message("GdError - not fully implemented for Atari Jaguar platform")
 	vsprintf(buf, format, args);
-#elif PSP
+#elif defined(PSP) && PSP
 	vsprintf(buf, format, args);
 	pspDebugScreenPrintf("%s\n", buf);
 #elif ANDROID
 	vsprintf(buf, format, args);
 	__android_log_print(ANDROID_LOG_INFO, "Microwindows", buf);
-#elif _MSC_VER
+#elif defined(_MSC_VER) && _MSC_VER
 	vsprintf(buf, format, args);
 	OutputDebugStringA(buf);
-#elif MSDOS
+#elif defined(MSDOS) && MSDOS
     {
 	static int fd = -1;
 	vsprintf(buf, format, args);
@@ -79,7 +79,7 @@ GdError(const char *format, ...)
 #elif EMSCRIPTEN
 	vsprintf(buf, format, args);
 	fprintf(stderr, "%s\n", buf);
-#elif ELKS
+#elif defined(ELKS) && ELKS
 	vsprintf(buf, format, args);
 	__dprintf("%s", buf);       /* write to /dev/console */
 #elif SWIEROS
@@ -122,15 +122,15 @@ GdGetTickCount(void)
 	gettimeofday(&t, NULL);
 	return ((t.tv_sec * 1000) + (t.tv_usec / 25000) * 25) - startTicks;
 	}
-#elif MSDOS
+#elif defined(MSDOS) && MSDOS
 	return (uint32_t)(clock() * 1000 / CLOCKS_PER_SEC);
-#elif _MINIX
+#elif defined(_MINIX) && _MINIX
 	{
 	struct tms	t;
 	
 	return (uint32_t)times(&t) * 16;
 	}
-#elif __ECOS
+#elif defined(__ECOS) && __ECOS
   /* CYGNUM_HAL_RTC_NUMERATOR/CYGNUM_HAL_RTC_DENOMINATOR gives the length of one tick in nanoseconds */
    return (cyg_current_time()*(CYGNUM_HAL_RTC_NUMERATOR/CYGNUM_HAL_RTC_DENOMINATOR))/(1000*1000);
 #else
@@ -155,11 +155,11 @@ GdDelay(MWTIMEOUT msecs)
 #pragma message("GdDelay - not implemented for Atari Jaguar platform")
 #elif EMSCRIPTEN
 	emscripten_sleep(msecs);
-#elif PSP
+#elif defined(PSP) && PSP
 	sceKernelDelayThread(1000 * msecs);
-#elif MSDOS
+#elif defined(MSDOS) && MSDOS
 	/* no delay required*/
-#elif _MSC_VER
+#elif defined(_MSC_VER) && _MSC_VER
 	Sleep(msecs);
 #else
 	/* no delay implemented*/
@@ -176,7 +176,7 @@ GdBell(void)
 #endif
 }
 
-#if PSP
+#if defined(PSP) && PSP
 static int
 exit_callback(void)
 {
@@ -205,7 +205,7 @@ GdPlatformInit(void)
 #if AJAGUAR
 #pragma message("GdPlatformInit - not implemented for Atari Jaguar platform")
 #endif
-#if PSP
+#if defined(PSP) && PSP
 	int thid = sceKernelCreateThread("update_thread", CallbackThread, 0x11, 0xFA0, 0, 0);
 	if (thid >= 0)
 		sceKernelStartThread(thid, 0, 0);
@@ -215,7 +215,7 @@ GdPlatformInit(void)
 #endif
 }
 
-#if _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER
 /* gettimeofday() for Windows*/
 
 int
@@ -242,7 +242,7 @@ gettimeofday(struct timeval *tv, struct timezone *tz)
 	}
 	if (tz)
 	{
-#if _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER
 		tz->tz_minuteswest = 7 * 60;	// FIXME
 		tz->tz_dsttime = 0;
 #else

--- a/src/drivers/scr_fb.c
+++ b/src/drivers/scr_fb.c
@@ -12,7 +12,7 @@
 #define _GNU_SOURCE 1
 #include <fcntl.h>
 #include <limits.h>
-#if LINUX
+#if defined(LINUX) && LINUX
 #include <linux/fb.h>
 #include <linux/kd.h>
 #include <linux/vt.h>
@@ -44,7 +44,7 @@ static void	set_directcolor_palette(PSD psd);
 
 /* static variables*/
 static int fb = -1;				/* framebuffer file handle*/
-#if LINUX
+#if defined(LINUX) && LINUX
 static short saved_red[16];		/* original hw palette*/
 static short saved_green[16];
 static short saved_blue[16];
@@ -122,7 +122,7 @@ fail:
 static PSD
 open_linuxfb(PSD psd)
 {
-#if LINUX
+#if defined(LINUX) && LINUX
 	int	type, visual;
 	int extra = getpagesize() - 1;
 	PSUBDRIVER subdriver;
@@ -139,7 +139,7 @@ open_linuxfb(PSD psd)
 	visual = fb_fix.visual;
 
 	psd->portrait = MWPORTRAIT_NONE;
-#if LINUX_SPARC
+#if defined(LINUX_SPARC) && LINUX_SPARC
 	psd->xres = psd->xvirtres = fb_var.xres_virtual;
 	psd->yres = psd->yvirtres = fb_var.yres_virtual;
 #else
@@ -226,7 +226,7 @@ open_linuxfb(PSD psd)
 	/* mmap framebuffer into this address space*/
 	psd->size = (psd->size + extra) & ~extra;		/* extend to page boundary*/
 
-#if LINUX_SPARC
+#if defined(LINUX_SPARC) && LINUX_SPARC
 #define CG3_MMAP_OFFSET 0x4000000
 #define CG6_RAM    		0x70016000
 #define TCX_RAM8BIT		0x00000000
@@ -280,7 +280,7 @@ fb_close(PSD psd)
 	/* if not opened, return*/
 	if (fb < 0)
 		return;
-#if LINUX
+#if defined(LINUX) && LINUX
   	/* reset hw palette*/
 	ioctl_setpalette(0, 16, saved_red, saved_green, saved_blue);
   

--- a/src/drivers/scr_nds.c
+++ b/src/drivers/scr_nds.c
@@ -57,7 +57,7 @@ static MWBOOL VGAMODE = TRUE;	/* ega or vga screen rows*/
 #define FNGR640x350	0x0010	/* function for graphics mode 640x350x16*/
 #define FNTEXT		0x0003	/* function for 80x25 text mode*/
 
-#if _MINIX
+#if defined(_MINIX) && _MINIX
 FARADDR int10(int mode, int z)
 {
 int fd;

--- a/src/drivers/scr_vga.c
+++ b/src/drivers/scr_vga.c
@@ -37,18 +37,18 @@
 #include <stdlib.h>
 #include <sys/ioctl.h>
 
-#if ELKS
+#if defined(ELKS) && ELKS
 #include <linuxmt/ntty.h>	/* DCGET_GRAPH ioctl */
 #define HWINIT		0	/* =1 for non-bios direct hardware init*/
 #define ROMFONT		0	/* =1 uses PC rom fonts */
-#elif _MINIX
+#elif defined(_MINIX) && _MINIX
 #include <fcntl.h>
 #include <unistd.h>
 #include <string.h>
 #include <ibm/int86.h>
 #define HWINIT		0
 #define ROMFONT		0
-#elif RTEMS
+#elif defined(RTEMS) && RTEMS
 #define HWINIT		1
 #define ROMFONT		0
 #else
@@ -108,7 +108,7 @@ VGA_open(PSD psd)
 		VGAMODE = FALSE;
 	else VGAMODE = TRUE;
 
-#if ELKS
+#if defined(ELKS) && ELKS
 	/* disallow console switching while in graphics mode*/
 	//ioctl(2, DCGET_GRAPH);
 #endif
@@ -143,7 +143,7 @@ VGA_open(PSD psd)
 static void
 VGA_close(PSD psd)
 {
-#if ELKS
+#if defined(ELKS) && ELKS
 	//ioctl(2, DCREL_GRAPH); /* allow console switching again*/
 #endif
 #if HWINIT
@@ -181,7 +181,7 @@ VGA_setpalette(PSD psd,int first,int count,MWPALENTRY *pal)
 	/* not yet implemented, std 16 color palette assumed*/
 }
 
-#if _MINIX
+#if defined(_MINIX) && _MINIX
 FARADDR int10(int mode, int z)
 {
    int fd;

--- a/src/drivers/vgaplan4.h
+++ b/src/drivers/vgaplan4.h
@@ -7,20 +7,20 @@
  */
 #define SLOWVGA		0	/* =1 for outb rather than outw instructions*/
 
-#if ELKS
+#if defined(ELKS) && ELKS
 #define HAVEFARPTR	1       /* =1 compiler has __far extension */
 #define INLINE_FP       1       /* =1 to inline xxx_FP functions */
 #define FAR         __far
-#elif _MINIX
+#elif defined(_MINIX) && _MINIX
 #define HAVEFARPTR	1
 #define INLINE_FP       0
 #define FAR
 #include <ibm/portio.h>
-#elif MSDOS
+#elif defined(MSDOS) && MSDOS
 #define HAVEFARPTR	1
 #define INLINE_FP       1
 #define FAR         _far
-#elif RTEMS
+#elif defined(RTEMS) && RTEMS
   #define FAR
   #define HAVEFARPTR    1
   #define INLINE_FP     1
@@ -60,7 +60,7 @@ extern void ORBYTE_FP(FARADDR,unsigned char);                   /* or byte at ad
 extern void ANDBYTE_FP(FARADDR,unsigned char);                  /* and byte at address*/
 #endif
 
-#if ELKS
+#if defined(ELKS) && ELKS
 #include <arch/io.h>
 #elif _MINIX | MSDOS
 #define	outb(v, p)	outb(p, v)

--- a/src/engine/devopen.c
+++ b/src/engine/devopen.c
@@ -14,7 +14,10 @@
 #include <stdlib.h>
 #include "device.h"
 
-#if MSDOS | ELKS
+#if defined(MSDOS) && MSDOS
+#define NOSTDPAL8
+#define NOSTDPAL2
+#elif defined(ELKS) && ELKS
 #define NOSTDPAL8
 #define NOSTDPAL2
 #endif

--- a/src/include/mwconfig.h
+++ b/src/include/mwconfig.h
@@ -352,7 +352,7 @@
 #define REALLOC(addr,oldsize,newsize) realloc((addr),(newsize))
 
 
-#if ELKS
+#if defined(ELKS) && ELKS
 #define EPRINTF			__dprintf
 #else
 int     GdError(const char *format, ...);
@@ -371,12 +371,15 @@ int     GdError(const char *format, ...);
 #endif
 
 /* no assert() in MSDOS or PSP */
-#if MSDOS | PSP
+#if defined(MSDOS) && MSDOS
+#undef assert
+#define assert(x)
+#elif defined(PSP) && PSP
 #undef assert
 #define assert(x)
 #endif
 
-#if RTEMS
+#if defined(RTEMS) && RTEMS
   /* RTEMS requires rtems_main()*/
   int rtems_main(int, char **);
   #define main	rtems_main

--- a/src/include/mwconfig.h
+++ b/src/include/mwconfig.h
@@ -347,7 +347,7 @@
 #define REALLOC(addr,oldsize,newsize) realloc((addr),(newsize))
 
 
-#if ELKS
+#if defined(ELKS) && ELKS
 #define EPRINTF			__dprintf
 #else
 int     GdError(const char *format, ...);
@@ -366,12 +366,15 @@ int     GdError(const char *format, ...);
 #endif
 
 /* no assert() in MSDOS or PSP */
-#if MSDOS | PSP
+#if defined(MSDOS) && MSDOS
+#undef assert
+#define assert(x)
+#elif defined(PSP) && PSP
 #undef assert
 #define assert(x)
 #endif
 
-#if RTEMS
+#if defined(RTEMS) && RTEMS
   /* RTEMS requires rtems_main()*/
   int rtems_main(int, char **);
   #define main	rtems_main

--- a/src/include/mwtypes.h
+++ b/src/include/mwtypes.h
@@ -18,7 +18,7 @@
 #include <stdint.h> 		/* for uint32_t, int32_t*/
 #endif
 
-#if __ECOS
+#if defined(__ECOS) && __ECOS
 #include <ecosmwconfig.h>	/*include the eCos configuration "translation" header */
 #endif
 
@@ -225,7 +225,7 @@
 #define MWPIXEL_FORMAT	MWPF_TRUECOLORARGB
 #endif
 
-#if ELKS
+#if defined(ELKS) && ELKS
 /* Force 8 bit palettized display for ELKS*/
 #undef MWPIXEL_FORMAT
 #define MWPIXEL_FORMAT	MWPF_PALETTE

--- a/src/include/nano-X.h
+++ b/src/include/nano-X.h
@@ -1023,28 +1023,28 @@ typedef struct {
  * NXDISPLAY will override GR_NAMED_SOCKET for the AF_UNIX case, or
  * specify the nano-X server address in the AF_INET case (default 127.0.0.1)
  */
-#if ELKS
+#if defined(ELKS) && ELKS
 #define GR_NAMED_SOCKET	"/tmp/nxsock"		/* ELKS socket name*/
 #else
 #define GR_NAMED_SOCKET	"/tmp/.nano-X"		/* AF_UNIX socket name*/
 #endif
 #define GR_NUM_SOCKET	6600			/* AF_INET socket number*/
 
-#if ELKS
+#if defined(ELKS) && ELKS
 #define GrError         __dprintf
 #else
 int     GdError(const char *format, ...);
 #define GrError         GdError
 #endif
 
-#if RTEMS
+#if defined(RTEMS) && RTEMS
   /* RTEMS requires rtems_main()*/
   int rtems_main(int, char **);
   #define main	rtems_main
 #endif
 
-#if NX_PER_CLIENT_DATA
-#if __ECOS
+#if defined(NX_PER_CLIENT_DATA) && NX_PER_CLIENT_DATA
+#if defined(__ECOS) && __ECOS
 #include <sys/select.h>
 #include <cyg/kernel/kapi.h>
 

--- a/src/include/nano-X.h
+++ b/src/include/nano-X.h
@@ -1023,27 +1023,27 @@ typedef struct {
  * NXDISPLAY will override GR_NAMED_SOCKET for the AF_UNIX case, or
  * specify the nano-X server address in the AF_INET case (default 127.0.0.1)
  */
-#if ELKS
+#if defined(ELKS) && ELKS
 #define GR_NAMED_SOCKET	"/tmp/nxsock"		/* ELKS socket name*/
 #else
 #define GR_NAMED_SOCKET	"/tmp/.nano-X"		/* AF_UNIX socket name*/
 #endif
 #define GR_NUM_SOCKET	6600			/* AF_INET socket number*/
 
-#if ELKS
+#if defined(ELKS) && ELKS
 #define GrError         __dprintf
 #else
 int     GdError(const char *format, ...);
 #define GrError         GdError
 #endif
 
-#if RTEMS
+#if defined(RTEMS) && RTEMS
   /* RTEMS requires rtems_main()*/
   int rtems_main(int, char **);
   #define main	rtems_main
 #endif
 
-#if __ECOS
+#if defined(__ECOS) && __ECOS
 #include <sys/select.h>
 #include <cyg/kernel/kapi.h>
 /*

--- a/src/include/nanowm.h
+++ b/src/include/nanowm.h
@@ -25,7 +25,7 @@
 
 /* nxPaintNCArea window drawing and color scheme*/
 #if NUKLEARUI						/* draw window frames/colors to match Nuklear style*/
-#if ELKS
+#if defined(ELKS) && ELKS
 #define SCHEME_NUK16 1              /* 16 color nuklear! */
 #define CYCAPTION	25				/* height of caption*/
 #define CYTEXTBASE  8               /* baseline for font */

--- a/src/include/swap.h
+++ b/src/include/swap.h
@@ -80,7 +80,7 @@
 /* Now, some platform-specific optimized macros.                         */
 /* ********************************************************************* */
 
-#if LINUX_POWERPPC
+#if defined(LINUX_POWERPPC) && LINUX_POWERPPC
 # if !MW_CPU_BIG_ENDIAN
 #  error POWERPC works in BIG ENDIAN only !!!
 # endif
@@ -104,7 +104,7 @@
 /* ********************************************************************* */
 /* MAC OSX                                                               */
 /* ********************************************************************* */
-#elif MACOSX
+#elif defined(MACOSX) && MACOSX
 
 /* ********************************************************************* */
 /* FreeBSD                                                               */
@@ -127,7 +127,7 @@
 /* ********************************************************************* */
 /* ECOS                                                                  */
 /* ********************************************************************* */
-#elif __ECOS
+#elif defined(__ECOS) && __ECOS
 
 /* although machine/endian.h might provide optimized versions,           */
 /* endian.h is only available if ecos is configured with networking      */
@@ -152,12 +152,12 @@
 /* *********************************************************************
  * RTEMS
  * ********************************************************************* */
-#elif RTEMS
+#elif defined(RTEMS) && RTEMS
 
 /* ********************************************************************* */
 /* TriMedia/pSOS                                                         */
 /* ********************************************************************* */
-#elif TRIMEDIA
+#elif defined(TRIMEDIA) && TRIMEDIA
 
 /* ********************************************************************* */
 /* Other                                                                 */

--- a/src/include/sys_time.h
+++ b/src/include/sys_time.h
@@ -7,10 +7,10 @@
  */
 
 
-#if _MINIX
+#if defined(_MINIX) && _MINIX
 #include <sys/times.h>
 
-#elif MSDOS
+#elif defined(MSDOS) && MSDOS
 #include <time.h>
 
 #elif defined(_MSC_VER)

--- a/src/include/uni_std.h
+++ b/src/include/uni_std.h
@@ -11,11 +11,20 @@
 #if !defined(_MSC_VER)
 #include <unistd.h>
 
-#if __MINGW32__
+#if defined(__MINGW32__) && __MINGW32__
 #include <malloc.h> 		/* for alloca */
 #endif
 
-#if RTEMS | PSP | __ECOS | __MINGW32__
+#if defined(RTEMS) && RTEMS
+#define  srandom  srand		/* Probably no more required for RTEMS */
+#define  random   rand
+#elif defined(PSP) && PSP
+#define  srandom  srand
+#define  random   rand
+#elif defined(__ECOS) && __ECOS
+#define  srandom  srand
+#define  random   rand
+#elif defined(__MINGW32__) && __MINGW32__
 #define  srandom  srand
 #define  random   rand
 #endif

--- a/src/include/winuser.h
+++ b/src/include/winuser.h
@@ -476,7 +476,7 @@ BOOL WINAPI	IsRectEmpty(CONST RECT *lprc);
 BOOL WINAPI	InflateRect(LPRECT lprc, int dx, int dy);
 BOOL WINAPI	OffsetRect(LPRECT lprc, int dx, int dy);
 /* The bcc compiler doesn't work passing structs by value, so we have this*/
-#if ELKS
+#if defined(ELKS) && ELKS
 #define		PtInRect(lprc,pt)	MwPTINRECT(lprc, *(long *)&(pt))
 #else
 #define		PtInRect(lprc,pt)	MwPTINRECT(lprc, pt)

--- a/src/mwin/wingdi.c
+++ b/src/mwin/wingdi.c
@@ -1342,7 +1342,7 @@ DrawDIB(HDC hdc,int x,int y,PMWIMAGEHDR pimage)
 #endif /* MW_FEATURE_IMAGES*/
 
 /* define color scheme: A (tan), B (winstd) or C (old)*/
-#if ELKS
+#if defined(ELKS) && ELKS
 #define B
 #else
 #define A

--- a/src/mwin/winmain.c
+++ b/src/mwin/winmain.c
@@ -11,11 +11,11 @@
 #include "uni_std.h"
 #include "sys_time.h"
 
-#if RTEMS
+#if defined(RTEMS) && RTEMS
 #include <rtems/mw_uid.h>
 #endif
 
-#if __ECOS
+#if defined(__ECOS) && __ECOS
 #include <cyg/kernel/kapi.h>
 #endif
 
@@ -278,7 +278,7 @@ MwSelect(BOOL canBlock)
 	 */
 	timeout = tout.tv_sec = tout.tv_usec = 0L;
 	to = &tout;
-#if NUTTX
+#if defined(NUTTX) && NUTTX
 	int poll = !canBlock;
 #else
 	int poll = (!canBlock || dragwp);		/* just poll if can't block or window move in progress*/

--- a/src/mwin/winmain.c
+++ b/src/mwin/winmain.c
@@ -11,11 +11,11 @@
 #include "uni_std.h"
 #include "sys_time.h"
 
-#if RTEMS
+#if defined(RTEMS) && RTEMS
 #include <rtems/mw_uid.h>
 #endif
 
-#if __ECOS
+#if defined(__ECOS) && __ECOS
 #include <cyg/kernel/kapi.h>
 #endif
 

--- a/src/nanox/client.c
+++ b/src/nanox/client.c
@@ -37,9 +37,9 @@
 #include <sys/shm.h>
 #endif
 
-#if ELKS
+#if defined(ELKS) && ELKS
 #define ADDR_FAM AF_UNIX
-#elif __ECOS
+#elif defined(__ECOS) && __ECOS
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <cyg/kernel/kapi.h>
@@ -71,7 +71,7 @@
  */
 #define SHM_BLOCK_SIZE	4096
 
-#if !NX_PER_CLIENT_DATA
+#if !defined(NX_PER_CLIENT_DATA) || !NX_PER_CLIENT_DATA
 /* exported global data */
 int 	   nxSocket = -1;	/* The network socket descriptor */
 LOCK_DECLARE(nxGlobalLock);	/* global lock for threads safety*/
@@ -460,7 +460,7 @@ GrClose(void)
 	close(nxSocket);
 	nxSocket = -1;
 	LOCK_FREE(&nxGlobalLock);
-#if ELKS
+#if defined(ELKS) && ELKS
 	GrDelay(500); /* partial raw terminal fix, allow nano-X to run to reset terminal */
 #endif
 }

--- a/src/nanox/client.c
+++ b/src/nanox/client.c
@@ -37,9 +37,9 @@
 #include <sys/shm.h>
 #endif
 
-#if ELKS
+#if defined(ELKS) && ELKS
 #define ADDR_FAM AF_UNIX
-#elif __ECOS
+#elif defined(__ECOS) && __ECOS
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <cyg/kernel/kapi.h>
@@ -71,7 +71,7 @@
  */
 #define SHM_BLOCK_SIZE	4096
 
-#if !__ECOS
+#if !defined(__ECOS) || !__ECOS
 /* exported global data */
 int 	   nxSocket = -1;	/* The network socket descriptor */
 LOCK_DECLARE(nxGlobalLock);	/* global lock for threads safety*/
@@ -443,7 +443,7 @@ GrClose(void)
 	close(nxSocket);
 	nxSocket = -1;
 	LOCK_FREE(&nxGlobalLock);
-#if ELKS
+#if defined(ELKS) && ELKS
 	GrDelay(500); /* partial raw terminal fix, allow nano-X to run to reset terminal */
 #endif
 }

--- a/src/nanox/clientfb.c
+++ b/src/nanox/clientfb.c
@@ -15,7 +15,7 @@
 #include <sys/mman.h>
 #endif
 
-#if !NX_PER_CLIENT_DATA
+#if !defined(NX_PER_CLIENT_DATA) || !NX_PER_CLIENT_DATA
 LOCK_EXTERN(nxGlobalLock);	/* global lock for threads safety*/
 #endif
 

--- a/src/nanox/nxpaintnc.c
+++ b/src/nanox/nxpaintnc.c
@@ -11,7 +11,7 @@
  */
 #define MWINCLUDECOLORS
 #include <stdlib.h>
-#if NX_PER_CLIENT_DATA
+#if defined(NX_PER_CLIENT_DATA) && NX_PER_CLIENT_DATA
 #include "serv.h"
 #endif
 #include "nano-X.h"

--- a/src/nanox/nxproto.c
+++ b/src/nanox/nxproto.c
@@ -11,7 +11,7 @@
 #include "nxproto.h"
 #include "lock.h"
 
-#if !NX_PER_CLIENT_DATA
+#if !defined(NX_PER_CLIENT_DATA) || !NX_PER_CLIENT_DATA
 static REQBUF	reqbuf;		/* request buffer*/
 extern int 	nxSocket;
 extern char *	nxSharedMem;

--- a/src/nanox/nxproto.c
+++ b/src/nanox/nxproto.c
@@ -11,7 +11,7 @@
 #include "nxproto.h"
 #include "lock.h"
 
-#if !__ECOS
+#if !defined(__ECOS) || !__ECOS
 static REQBUF	reqbuf;		/* request buffer*/
 extern int 	nxSocket;
 extern char *	nxSharedMem;

--- a/src/nanox/nxproto.h
+++ b/src/nanox/nxproto.h
@@ -33,7 +33,7 @@
  * NOTE: MAXREQUESTSZ must be an _aligned_ multiple of 4, meaning
  * that MAXREQUESTSZ = (MAXREQUESTSZ + 3) & ~3.
  */
-#if ELKS
+#if defined(ELKS) && ELKS
 #define MAXREQUESTSZ	512             /* max request size FIXME */
 #define SZREQBUF        512	        /* initial request buffer size*/
 #else
@@ -46,7 +46,7 @@ typedef unsigned short	UINT16;		/* 2 bytes*/
 typedef short		INT16;		/* 2 bytes*/
 typedef unsigned long	UINT32;		/* 4 bytes*/
 
-#if ELKS
+#if defined(ELKS) && ELKS
 typedef UINT16		IDTYPE;
 #define ALIGNSZ		2	/* 2 byte packet alignment*/
 #else
@@ -74,7 +74,7 @@ typedef struct {
 
 /* FIXME fails when sizeof(int) == 2*/
 /* get request total valid data length, including header*/
-#if ELKS
+#if defined(ELKS) && ELKS
 #define GetReqLen(req)		((req)->length)     /* FIXME check hilength */
 #else
 #define GetReqLen(req)		(((req)->hilength << 16) | (req)->length)

--- a/src/nanox/serv.h
+++ b/src/nanox/serv.h
@@ -10,7 +10,7 @@
  * These definitions are not to be used by clients.
  */
 
-#if NX_PER_CLIENT_DATA && !defined(_NO_SVR_MAPPING)
+#if defined(NX_PER_CLIENT_DATA) && NX_PER_CLIENT_DATA && !defined(_NO_SVR_MAPPING)
 /*
  * In a single process, multi-threaded environment (NX_PER_CLIENT_DATA),
  * the server and the client code share the same namespace.  This means

--- a/src/nanox/serv.h
+++ b/src/nanox/serv.h
@@ -10,7 +10,7 @@
  * These definitions are not to be used by clients.
  */
 
-#if __ECOS && !defined(_NO_SVR_MAPPING)
+#if defined(__ECOS) && __ECOS && !defined(_NO_SVR_MAPPING)
 /*
  * Since eCos is a single task, multi-threaded environment, the
  * server and the client code share the same namespace.  This means

--- a/src/nanox/srvfunc.c
+++ b/src/nanox/srvfunc.c
@@ -576,7 +576,7 @@ GrMoveWindow(GR_WINDOW_ID wid, GR_COORD x, GR_COORD y)
 		return;
 	}
 #endif
-#if ELKS
+#if defined(ELKS) && ELKS
 	/* perform quick move and expose if topmost and mapped - no blit*/
 	if (wp->mapped && wp == wp->parent->children) {
 		int	oldx = wp->x;

--- a/src/nanox/srvmain.c
+++ b/src/nanox/srvmain.c
@@ -13,7 +13,7 @@
 #include "uni_std.h"
 #include "sys_time.h"
 
-#if RTEMS
+#if defined(RTEMS) && RTEMS
 #include <rtems/mw_uid.h>
 #endif
 
@@ -248,7 +248,7 @@ GrOpen(void)
 	}
 	SERVER_UNLOCK();
 
-#if MSDOS
+#if defined(MSDOS) && MSDOS
 	atexit(GsTerminate);
 #endif
 #endif /* NONETWORK*/
@@ -586,7 +586,7 @@ again:
 }
 
 /********************************************************************************/
-#elif RTEMS
+#elif defined(RTEMS) && RTEMS
 extern struct MW_UID_MESSAGE m_kbd;
 extern struct MW_UID_MESSAGE m_mou;
 
@@ -922,7 +922,7 @@ GsInitialize(void)
 
 	if (GsOpenSocket() < 0) {
 		EPRINTF("nano-X: Cannot bind to named socket"
-#if ELKS
+#if defined(ELKS) && ELKS
 			", check CONFIG_UNIX (UNIX sockets) enabled"
 #endif
 			"\n");
@@ -1064,7 +1064,7 @@ GsTerminate(void)
 #if VTSWITCH
 	MwRedrawVt(mwvterm);
 #endif
-#if ELKS
+#if defined(ELKS) && ELKS
 	write(1, "\033[25;1H", 7);
 #endif
 	_exit(0);

--- a/src/nanox/srvnet.c
+++ b/src/nanox/srvnet.c
@@ -22,7 +22,7 @@
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #endif
-#if __ECOS
+#if defined(__ECOS) && __ECOS
 #include <netinet/in.h>
 #else
 #include <sys/un.h>
@@ -1856,7 +1856,7 @@ GrShmCmdsFlushWrapper(void *r)
 int 
 GsOpenSocket(void)
 {
-#if __ECOS
+#if defined(__ECOS) && __ECOS
 	struct sockaddr_in sckt;
 #else
 	struct sockaddr_un sckt;
@@ -1865,7 +1865,7 @@ GsOpenSocket(void)
 #define SUN_LEN(ptr)	(sizeof(sckt))
 #endif
 
-#if __ECOS
+#if defined(__ECOS) && __ECOS
 	/* Create the socket */
 	if((un_sock = socket(AF_INET, SOCK_STREAM, 0)) == -1) 
 	    return -1;
@@ -1913,7 +1913,7 @@ void
 GsAcceptClient(void)
 {
 	int i;
-#if __ECOS
+#if defined(__ECOS) && __ECOS
 	struct sockaddr_in sckt;
 #else
 	struct sockaddr_un sckt;

--- a/src/nx11/StrKeysym.c
+++ b/src/nx11/StrKeysym.c
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include "uni_std.h"
 #include <fcntl.h>
-#if !__MINGW32__
+#if !defined(__MINGW32__) || !__MINGW32__
 #include <sys/ioctl.h>
 #endif
 

--- a/src/nx11/fontlist.c
+++ b/src/nx11/fontlist.c
@@ -28,13 +28,13 @@ char *FONT_DIR_LIST[] = {
     XLOCALFONTPATH,                             /* path to mwin fonts directory*/
     XLOCALFONTPATH "/pcf",                      /* mwin pcf fonts w/fonts.dir*/
     XLOCALFONTPATH "/truetype",                 /* mwin .ttf/.otf fonts w/fonts.dir*/
-#if MACOSX && HAVE_SYSTEM_FONT_PATHS
+#if defined(MACOSX) && MACOSX && HAVE_SYSTEM_FONT_PATHS
     MACOSX_SYSTEM_PATH "TTF",
     MACOSX_SYSTEM_PATH "truetype",
     MACOSX_SYSTEM_PATH "100dpi",
     MACOSX_SYSTEM_PATH "misc",
 #endif
-#if LINUX && HAVE_SYSTEM_FONT_PATHS
+#if defined(LINUX) && LINUX && HAVE_SYSTEM_FONT_PATHS
     LINUX_SYSTEM_PATH "X11/misc",               /* pcf fonts w/fonts.dir*/
     LINUX_SYSTEM_PATH "X11/100dpi",
     LINUX_SYSTEM_PATH "truetype",               /* truetype fonts, Suse 64bit distro*/
@@ -43,13 +43,13 @@ char *FONT_DIR_LIST[] = {
     LINUX_SYSTEM_PATH "truetype/openoffice",
     LINUX_SYSTEM_PATH "X11/Type1",              /* t1lib type1 .pfb fonts, w/fonts.dir*/
 #endif
-#if MSDOS && HAVE_SYSTEM_FONT_PATHS
+#if defined(MSDOS) && MSDOS && HAVE_SYSTEM_FONT_PATHS
     MSDOS_SYSTEM_PATH,
 #endif
-#if ANDROID && HAVE_SYSTEM_FONT_PATHS
+#if defined(ANDROID) && ANDROID && HAVE_SYSTEM_FONT_PATHS
     ANDROID_SYSTEM_PATH,
 #endif
-#if OTHER
+#if defined(OTHER) && OTHER
     "/var/lib/defoma/x-ttcidfont-conf.d/dirs/TrueType",
 #endif
     0


### PR DESCRIPTION
…nings

The conditionalized code define checks for specific target changed to pattern with initial check for define presence

  #if defined(ELKS) && ELKS

This resolves -Wundef warnings.