### PR TITLE
Fix some lint issues in nuttx

### DIFF
--- a/src/drivers/fb.c
+++ b/src/drivers/fb.c
@@ -105,7 +105,9 @@ select_fb_subdriver(PSD psd)
 	extern PSUBDRIVER fblinear24[4];
 	extern PSUBDRIVER fblinear32bgra[4];
 	extern PSUBDRIVER fblinear32rgba[4];
+#if ELKS
 	extern PSUBDRIVER memplan4[4];
+#endif
 
 #if ELKS
 	pdriver = memplan4;

--- a/src/drivers/rasterops.c
+++ b/src/drivers/rasterops.c
@@ -307,35 +307,35 @@ GdRasterOp(PMWIMAGEHDR pixd, MWCOORD dx, MWCOORD dy, MWCOORD dw, MWCOORD dh, int
 	/* translate op to pix library format*/
 	op = raster_ops[op];
 
-    if (op == PIX_DST)   /* no-op */
-        return;
+	if (op == PIX_DST)   /* no-op */
+		return;
 
 	/* check padding to 32-bit boundary*/
 	assert((pixd->pitch & 3) == 0);
 
 	/* Check if operation is only on dest */
-    dd = pixGetDepth(pixd);
-    if (op == PIX_CLR || op == PIX_SET || op == PIX_NOT(PIX_DST)) {
-        rasteropUniLow(pixGetData(pixd),
-                       pixGetWidth(pixd), pixGetHeight(pixd), dd,
-                       pixGetWpl(pixd),
-                       dx, dy, dw, dh,
-                       op);
-        return;
-    }
+	dd = pixGetDepth(pixd);
+	if (op == PIX_CLR || op == PIX_SET || op == PIX_NOT(PIX_DST)) {
+		rasteropUniLow(pixGetData(pixd),
+		               pixGetWidth(pixd), pixGetHeight(pixd), dd,
+		               pixGetWpl(pixd),
+		               dx, dy, dw, dh,
+		               op);
+		return;
+	}
 
 	/* Check depth of src and dest; these must agree */
-    assert(dd == pixGetDepth(pixs));
+	assert(dd == pixGetDepth(pixs));
 
-    rasteropLow(pixGetData(pixd),
-                pixGetWidth(pixd), pixGetHeight(pixd), dd,
-                pixGetWpl(pixd),
-                dx, dy, dw, dh,
-                op,
-                pixGetData(pixs),
-                pixGetWidth(pixs), pixGetHeight(pixs),
-                pixGetWpl(pixs),
-                sx, sy);
+	rasteropLow(pixGetData(pixd),
+	            pixGetWidth(pixd), pixGetHeight(pixd), dd,
+	            pixGetWpl(pixd),
+	            dx, dy, dw, dh,
+	            op,
+	            pixGetData(pixs),
+	            pixGetWidth(pixs), pixGetHeight(pixs),
+	            pixGetWpl(pixs),
+	            sx, sy);
 }
 
 /*

--- a/src/include/windef.h
+++ b/src/include/windef.h
@@ -165,9 +165,9 @@ typedef LPCSTR LPCTSTR;
 #define __TEXT(quote) quote
 #define TEXT(quote) __TEXT(quote)
 
-typedef int (FAR *FARPROC)();
-typedef int (NEAR *NEARPROC)();
-typedef int (*PROC)();
+typedef int (FAR *FARPROC)(void);
+typedef int (NEAR *NEARPROC)(void);
+typedef int (*PROC)(void);
 
 #define MAKEWORD(a, b)      ((WORD)(((BYTE)(a)) | ((WORD)((BYTE)(b))) << 8))
 #define MAKELONG(a, b)      ((LONG)(((WORD)(a)) | ((DWORD)((WORD)(b))) << 16))


### PR DESCRIPTION
Hi, @ghaerr . Could we fix some ci `-Werror` issue mentioned in https://github.com/apache/nuttx/pull/19912 here?

- Guard the memplan4 framebuffer subdriver declaration with #if ELKS so it is not an unused variable on non-ELKS builds.
- Convert the space-indented statements in GdRasterOp to tabs to fix the misleading-indentation warning.
- Declare FARPROC, NEARPROC and PROC with (void) parameters to fix the strict-prototypes warning.