### PR TITLE
Fix backspace generates incorrect character in nuttx

### DIFF
--- a/src/drivers/kbd_nuttx_common.h
+++ b/src/drivers/kbd_nuttx_common.h
@@ -78,6 +78,23 @@ static MWKEY translate_keycode(uint32_t code)
     }
 }
 
+static MWKEY translate_ascii_byte(uint32_t code)
+{
+  switch (code)
+    {
+    case 0x7f:
+      return MWKEY_BACKSPACE;
+    case 0x0a:
+      return MWKEY_ENTER;
+    default:
+      if (code < 128)
+        {
+          return (MWKEY)code;
+        }
+      return MWKEY_UNKNOWN;
+    }
+}
+
 static void update_modifiers(MWKEYMOD *modifiers, MWKEY key, int press)
 {
   MWKEYMOD mask = 0;

--- a/src/drivers/kbd_nuttx_event.c
+++ b/src/drivers/kbd_nuttx_event.c
@@ -92,7 +92,7 @@ static int nuttxkbd_Read(MWKEY *kbuf, MWKEYMOD *mods, MWSCANCODE *scancode)
   key = event.type == KBD_SPECPRESS ||
         event.type == KBD_SPECREL ?
         translate_keycode(event.code) :
-        event.code;
+        translate_ascii_byte(event.code);
   press = (event.type == KBD_PRESS) ||
         event.type == KBD_SPECPRESS;
 

--- a/src/drivers/kbd_nuttx_raw.c
+++ b/src/drivers/kbd_nuttx_raw.c
@@ -38,23 +38,6 @@ KBDDEVICE kbddev =
   NULL
 };
 
-static MWKEY raw_byte_to_mwkey(uint8_t ch)
-{
-  switch (ch)
-    {
-    case 0x7f:
-      return MWKEY_BACKSPACE;
-    case 0x0a:
-      return MWKEY_ENTER;
-    default:
-      if (ch < 128)
-        {
-          return (MWKEY)ch;
-        }
-      return MWKEY_UNKNOWN;
-    }
-}
-
 static void raw_reset(void)
 {
   raw_buf_len = 0;
@@ -162,7 +145,7 @@ static int nuttxkbd_Read(MWKEY *kbuf, MWKEYMOD *mods, MWSCANCODE *scancode)
 
     case KBD_PRESS:
       {
-        MWKEY key = raw_byte_to_mwkey(ch);
+        MWKEY key = translate_ascii_byte(ch);
         if (key == MWKEY_UNKNOWN)
           {
             return KBD_NODATA;


### PR DESCRIPTION
Move the byte to MWKEY translation (0x7f -> MWKEY_BACKSPACE, 0x0a -> MWKEY_ENTER) into kbd_nuttx_common.h and use it in both the raw and the event driver.

This fix the issue that backspace generates incorrect character in nuttx.