### PR TITLE
Intrusiveness minimizing changes to suppress warnings for build inside NuttX tree

### DIFF
--- a/src/images/tools/convbmp.c
+++ b/src/images/tools/convbmp.c
@@ -376,16 +376,16 @@ UCHAR *p = (UCHAR *)&l;
 
 	for(i = cy-1; i>= 0; i--) {
 		/* turn image rightside up*/
-		unsigned char *p = imagebits + i*pitch;
+		unsigned char *p1 = imagebits + i*pitch;
 
 		if(compression == BI_RLE8) {
-			if(!DecodeRLE8(p, fp))
+			if(!DecodeRLE8(p1, fp))
 				break;
 		} else if(compression == BI_RLE4) {
-			if(!DecodeRLE4(p, fp))
+			if(!DecodeRLE4(p1, fp))
 				break;
 		} else {
-			if(fread(p, 1, pitch, fp) != (size_t)pitch) {
+			if(fread(p1, 1, pitch, fp) != (size_t)pitch) {
 				free(imagebits);
 				fprintf(stderr, "Error fread\n");
 				return -1;
@@ -401,9 +401,9 @@ UCHAR *p = (UCHAR *)&l;
 
 	/* then output each line in order*/
 	for (i=0; i<cy; i++) {
-		unsigned char *p = imagebits + i*pitch;
+		unsigned char *p1 = imagebits + i*pitch;
 
-		outline(p, bitdepth, pitch);
+		outline(p1, bitdepth, pitch);
 	}
 
    if(!s_flag) {
@@ -570,6 +570,7 @@ int		c, n, c1, c2;
 				continue;
 			default:			/* 0 3..255 xx nn uncompressed data*/
 				c2 = (n+3) & ~3;
+				c1 = 0;			/* initialize to suppress false warning */
 				for(c=0; c<c2; c++) {
 					if((c & 1) == 0)
 							c1 = fgetc(fp);

--- a/src/include/mwconfig.nuttx
+++ b/src/include/mwconfig.nuttx
@@ -2,6 +2,8 @@
  * Included by mwconfig.h via -DMWCONFIG_FILE='"mwconfig.nuttx"'
  */
 
+#pragma GCC diagnostic ignored "-Wundef"
+
 #undef  NUTTX
 #define NUTTX               1
 #ifndef NANOWM

--- a/src/include/nano-X.h
+++ b/src/include/nano-X.h
@@ -962,13 +962,17 @@ GR_CURSOR_ID GrSetCursor(GR_WINDOW_ID wid, GR_SIZE width, GR_SIZE height,
 				GR_COORD hotx, GR_COORD hoty, GR_COLOR foreground,
 				GR_COLOR background, GR_BITMAP *fbbitmap, GR_BITMAP *bgbitmap);
 /*#define GrSetBorderColor			GrSetWindowBorderColor*/
+#undef GrCreateFont
 #define GrCreateFont(name,height,plogfont)	GrCreateFontEx(name,height,height,plogfont)
+#undef GrSetFontSize
 #define GrSetFontSize(fontid,height)		GrSetFontSizeEx(fontid,height,height)
+#undef GrNewPixmap
 #define GrNewPixmap(width,height,pixels)	GrNewPixmapEx(width,height,0,pixels)
 
 /* useful function macros*/
 #define GrClearWindow(wid,exposeflag)		GrClearArea(wid,0,0,0,0,exposeflag)
 #define GrFlushWindow(wid)			GrClearWindow(wid,2)
+#undef GrDrawImageToFit
 #define GrDrawImageToFit(id,gc,x,y,width,height,imageid) \
 		GrDrawImagePartToFit(id,gc,x,y,width,height,0,0,0,0,imageid)
 #define GrSetWindowBackgroundColor(wid,color) \

--- a/src/mwin/wingdi.c
+++ b/src/mwin/wingdi.c
@@ -33,7 +33,7 @@ static MWBITMAPOBJ default_bitmap = {
 };
 
 static MWPALOBJ default_palette = {
-	{OBJ_PAL, TRUE}, 0, 0
+	{OBJ_PAL, TRUE}, {0, 0}
 };
 
 static BOOL MwExtTextOut(HDC hdc, int x, int y, UINT fuOptions,
@@ -784,7 +784,8 @@ FillRect(HDC hdc, CONST RECT *lprc, HBRUSH hbr)
 
 	/* handle COLOR_xxx + 1 passed as HBRUSH*/
 	if((UINT_PTR)obr <= MAXSYSCOLORS) {		// Convert pointer to long without truncation to check if small int passed
-		crFill = GetSysColor((int)obr-1);	// OK: Not pointer. Convert to int then decrement.
+		// OK: Not pointer. Convert to int then decrement.
+		crFill = GetSysColor((int)(UINT_PTR)obr-1);
 	} else {
 		/* get color from passed HBRUSH*/
 		if(obr->style == BS_NULL)

--- a/src/mwin/winlib/combobox.c
+++ b/src/mwin/winlib/combobox.c
@@ -347,7 +347,7 @@ DefComboboxProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         lp->bExtended = TRUE;
         lp->hFont = 0;
         lp->hWndParent = lpcs->hwndParent;
-        lp->nID = (UINT) lpcs->hMenu;        //OK:  Not pointer, control id always passed as UINT.
+        lp->nID = (UINT)(UINT_PTR) lpcs->hMenu; //OK:  Not pointer, control id always passed as UINT.
 
             dwStyle = GetWindowLong(hWnd, GWL_STYLE);
         dwStyle &= ~(WS_VSCROLL | WS_HSCROLL | WS_BORDER | WS_DLGFRAME | WS_THICKFRAME);

--- a/src/mwin/winres.c
+++ b/src/mwin/winres.c
@@ -64,7 +64,8 @@ mwAddResource(HRSRC hRes)
 static int
 mwResCompare(LPCTSTR res1, LPCTSTR res2)
 {
-	if ((HIWORD(res1) == 0xFFFF) || (HIWORD(res2) == 0xFFFF))	// OK: Not pointer. Checks high word of resource DWORD.
+	// OK: Not pointer. Checks high word of resource DWORD.
+	if ((HIWORD((UINT_PTR)res1) == 0xFFFF) || (HIWORD((UINT_PTR)res2) == 0xFFFF))
 		return (res1 != res2);
 
 	// FIXME: resource string names not handled properly here
@@ -258,14 +259,14 @@ mwIsSameType(FILE * f, LPCTSTR id, BOOL * pEof)
 		return !(*pEof);
 	}
 	//  Resource may be specified in text or integer
-	if (HIWORD(id) == 0xFFFF) {
+	if (HIWORD((UINT_PTR)id) == 0xFFFF) {
 		w = resReadWord(f, pEof);
 		if (w != 0xFFFF)
 			return FALSE;
 		w = resReadWord(f, pEof);
 		if (*pEof)
 			return FALSE;
-		if (w == LOWORD((DWORD) id))
+		if (w == LOWORD((UINT_PTR) id))
 			return TRUE;
 	} else {
 		LPCTSTR p = id;
@@ -538,8 +539,8 @@ resDialogTemplate(BYTE *dest, LPCSTR caption, DWORD style, DWORD dwExtendedStyle
 	dialog->cdit = (WORD)cdit;
 
 	extra = (WORD *)(((BYTE *)dialog) + FIXSZ_MWDLGTEMPLATE);
-	*extra++ = (WORD)menu;		// OK: No string menus yet, menu id always passed as WORD.
-	*extra++ = (WORD)classname;	// OK: No string classes yet, class id always passed as WORD.
+	*extra++ = (WORD)(UINT_PTR)menu;	// OK: No string menus yet, menu id always passed as WORD.
+	*extra++ = (WORD)(UINT_PTR)classname;	// OK: No string classes yet, class id always passed as WORD.
 	if (caption)
 		while (*caption)
 			*extra++ = (WORD)*caption++;

--- a/src/mwin/winsbar.c
+++ b/src/mwin/winsbar.c
@@ -797,14 +797,14 @@ ShowScrollBar (HWND hWnd, int iSBar, BOOL bShow)
 
     {
         RECT rcWin, rcClient;
-        
+
         memcpy (&rcWin, &pWin->winrect.left, sizeof (RECT));
         rcClient.left = 0;
         rcClient.top  = 0;
         rcClient.right = pWin->clirect.right - pWin->clirect.left;
         rcClient.bottom = pWin->clirect.bottom - pWin->clirect.top;
-
-		/* fix: no WM_SIZECHANGED */
+        (void)rcClient;
+        /* fix: no WM_SIZECHANGED */
         //SendMessage(hWnd, WM_SIZECHANGED, (WPARAM)&rcWin, (LPARAM)&rcClient);
     }
     

--- a/src/mwin/winuser.c
+++ b/src/mwin/winuser.c
@@ -489,7 +489,7 @@ CreateWindowEx(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName,
 	wp->cursor = pwp->cursor;
 	wp->cursor->usecount++;
 	wp->unmapcount = pwp->unmapcount + 1;
-	wp->id = (int)hMenu;				// OK: Not pointer. Menu id always passed as int.
+	wp->id = (int)(UINT_PTR)hMenu;				// OK: Not pointer. Menu id always passed as int.
 	wp->gotPaintMsg = PAINT_PAINTED;
 
 	titLen = 0;
@@ -1300,8 +1300,8 @@ GetClassLong(HWND hwnd, int nIndex)
 	case GCL_CBWNDEXTRA:
 		return (DWORD)hwnd->pClass->cbWndExtra;
 	case GCL_HBRBACKGROUND:
-		assert(sizeof(LONG_PTR) <= 32);		// 64bit must use GetClassLongPtr
-		return (DWORD)hwnd->pClass->hbrBackground;		// OK: Pointer size checked above and is 32 bit.
+		assert(sizeof(LONG_PTR) <= sizeof(DWORD));	// 64bit must use GetClassLongPtr
+		return (DWORD)(LONG_PTR)hwnd->pClass->hbrBackground;	// OK: Pointer size checked above and is 32 bit.
 	case GCL_HCURSOR:
 	case GCL_HICON:
 	case GCL_HMODULE:
@@ -1391,7 +1391,7 @@ SetWindowLongPtr(HWND hwnd, int nIndex, LONG_PTR lNewLong)
 		hwnd->lpfnWndProc = (WNDPROC)lNewLong;
 		break;
 	case GWL_WNDPROCBRIDGE:
-		hwnd->lpfnWndProcBridge = (WNDPROC)lNewLong;
+		hwnd->lpfnWndProcBridge = (WNDPROC)(UINT_PTR)lNewLong;
 		break;
 	case GWL_HINSTANCE:
 		hwnd->hInstance = (HINSTANCE)lNewLong;
@@ -1514,7 +1514,7 @@ SetProp(HWND hWnd, LPCSTR lpString, HANDLE hData)
 		return FALSE;
 	/* check if 16 bit atom passed instead of pointer*/
 	if (PTR_IS_ATOM(lpString))
-		pProp->Atom = LOWORD((DWORD)lpString);			// OK: Not pointer. Atom passed in low 16 bits.
+		pProp->Atom = LOWORD((DWORD)(UINT_PTR)lpString);	// OK: Not pointer. Atom passed in low 16 bits.
 	else
 		pProp->Atom = GlobalAddAtom(lpString);
 	pProp->hData = hData;
@@ -1532,7 +1532,7 @@ GetProp(HWND hWnd, LPCSTR lpString)
 
 	/* check if 16 bit atom passed instead of pointer*/
 	if (PTR_IS_ATOM(lpString))
-		Atom = LOWORD((DWORD)lpString);				// OK: Not pointer. Atom passed in low 16 bits.
+		Atom = LOWORD((DWORD)(UINT_PTR)lpString);	// OK: Not pointer. Atom passed in low 16 bits.
 	else
 		Atom = GlobalFindAtom(lpString);
 
@@ -1554,7 +1554,7 @@ RemoveProp(HWND hWnd, LPCSTR lpString)
 
 	/* check if 16 bit atom passed instead of pointer*/
 	if (PTR_IS_ATOM(lpString))
-		Atom = LOWORD((DWORD)lpString);				// OK: Not pointer. Atom passed in low 16 bits.
+		Atom = LOWORD((DWORD)(UINT_PTR)lpString);	// OK: Not pointer. Atom passed in low 16 bits.
 	else
 		Atom = GlobalFindAtom(lpString);
 
@@ -1656,11 +1656,11 @@ SetWindowPos(HWND hwnd, HWND hwndInsertAfter, int x, int y, int cx, int cy, UINT
 	hidden = hwnd->unmapcount || (fuFlags & SWP_NOREDRAW);
 
 	if(bZorder) {
-		switch((int)hwndInsertAfter) {			// OK: intentional HWND to int cast
-		case (int)(HWND)HWND_TOP:				// OK: intentional HWND to int cast
+		switch((int)(UINT_PTR)hwndInsertAfter) {	// OK: intentional HWND to int cast
+		case (int)(UINT_PTR)(HWND)HWND_TOP:		// OK: intentional HWND to int cast
 			MwRaiseWindow(hwnd);
 			break;
-		case (int)(HWND)HWND_BOTTOM:			// OK: intentional HWND to int cast
+		case (int)(UINT_PTR)(HWND)HWND_BOTTOM:		// OK: intentional HWND to int cast
 			MwLowerWindow(hwnd);
 			break;
 		default:

--- a/src/nanox/client.c
+++ b/src/nanox/client.c
@@ -4498,6 +4498,7 @@ GrQueryPointer(GR_WINDOW_ID *mwin, GR_COORD *x, GR_COORD *y, GR_BUTTON *bmask)
 
 	LOCK(&nxGlobalLock);
 	req = AllocReq(QueryPointer);
+	(void)req;
 	TypedReadBlock(mwin, sizeof(*mwin), GrNumQueryPointer);
 	ReadBlock(x, sizeof(*x));
 	ReadBlock(y, sizeof(*y));

--- a/src/nanox/serv.h
+++ b/src/nanox/serv.h
@@ -33,6 +33,7 @@
 #define GrCloseWindow           SVR_GrCloseWindow
 #define GrCopyArea              SVR_GrCopyArea
 #define GrCopyGC                SVR_GrCopyGC
+#undef GrCreateFont
 #define GrCreateFont            SVR_GrCreateFont
 #define GrCreateFontEx          SVR_GrCreateFontEx
 #define GrCreateTimer		SVR_GrCreateTimer        
@@ -47,6 +48,7 @@
 #define GrDrawImageFromBuffer	SVR_GrDrawImageFromBuffer
 #define GrDrawImageFromFile     SVR_GrDrawImageFromFile
 #define GrDrawImagePartToFit    SVR_GrDrawImagePartToFit
+#undef GrDrawImageToFit
 #define GrDrawImageToFit        SVR_GrDrawImageToFit
 #define GrEllipse               SVR_GrEllipse
 #define GrEmptyRegion           SVR_GrEmptyRegion
@@ -86,6 +88,7 @@
 #define GrNewCursor		SVR_GrNewCursor          
 #define GrNewGC                 SVR_GrNewGC
 #define GrNewInputWindow        SVR_GrNewInputWindow
+#undef GrNewPixmap
 #define GrNewPixmap             SVR_GrNewPixmap
 #define GrNewPixmapEx           SVR_GrNewPixmapEx
 #define GrNewPolygonRegion      SVR_GrNewPolygonRegion
@@ -114,6 +117,7 @@
 #define GrSetFocus              SVR_GrSetFocus
 #define GrSetFontAttr           SVR_GrSetFontAttr
 #define GrSetFontRotation       SVR_GrSetFontRotation
+#undef GrSetFontSize
 #define GrSetFontSize           SVR_GrSetFontSize
 #define GrSetFontSizeEx         SVR_GrSetFontSizeEx
 #define GrSetGCBackground       SVR_GrSetGCBackground


### PR DESCRIPTION
@ghaerr @Acfboy @acassis I have prepared changes which suppress all warnings in NuttX build including Microwindows and Nano-X demos except the last two
```
CC:  nxcalc.c nxcalc.c: In function ‘press_button’:
nxcalc.c:383:42: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
  383 |           snprintf(tmp, sizeof(tmp), "-%s", display);
      |                                          ^
nxcalc.c:383:11: note: ‘snprintf’ output between 2 and 129 bytes into a destination of size 128
  383 |           snprintf(tmp, sizeof(tmp), "-%s", display);
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
CC:  microwindows/src/nanox/client.c microwindows/src/nanox/client.c: In function ‘GrQueryPointer’:
microwindows/src/nanox/client.c:4497:28: warning: variable ‘req’ set but not used [-Wunused-but-set-variable]
 4497 |         nxQueryPointerReq *req;
      |                            ^~~
```
The second one is easy to fix as well but it is question if they should not be investigated the first to decide whether they should not stay or be replaced by TODO.

If the changes are acceptable and accepted, then the new SHA for Microwindows should be updated in

https://github.com/apache/nuttx-apps/pull/3768

and it should open door to merge documentation and configurations

https://github.com/apache/nuttx/pull/19912

I have tested build for `qemu-intel64` and did not test the result even for functionality till now. It should be tested on some 32-bit NuttX target as well and should be checked to not make problems for other non-NuttX active targets.